### PR TITLE
Allow to set ENVS for items such as http/no_proxy

### DIFF
--- a/charts/aws-pca-issuer/templates/deployment.yaml
+++ b/charts/aws-pca-issuer/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.envs }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - /manager
           args:

--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -66,3 +66,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+envs: []
+# - name: SOME_VAR
+#   value: 'some value'

--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -70,3 +70,4 @@ affinity: {}
 envs: []
 # - name: SOME_VAR
 #   value: 'some value'
+


### PR DESCRIPTION
We need to set proxy settings in our AWS env.

This allows setting any ENV variable to the container such as http_proxy/https_proxy/no_proxy/etc.

