### PR TITLE
Add GitHub action to sync README and CRDs

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,3 +1,4 @@
+# workflows to sync certain files when changes are pushed to the master branch
 name: Sync
 
 on:
@@ -6,7 +7,7 @@ on:
       - 'master'
     paths:
       - 'README.md'
-  pull_request:
+  pull_request_target:
     branches:
       - 'master'
     paths:
@@ -43,25 +44,28 @@ jobs:
             echo "Nothing committed, not pushing."
           fi
 
-  # Check if CRDs are modified in charts or config or both.
-  # Unfortunately we cannot overwrite contributor's changes
-  # using the update-pull-request-action, so we check which
-  # CRDs were changed and copy those over the unchanged CRDs.
-  # If both CRDs are changed and not equal, we fail the workflow
-  # and post a comment on the PR informing the contributor
-  # that the CRDs must be identical.
   sync-crds:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
 
       - name: Check which CRDs are modified
         id: which-crd-modified
         run: |
           URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
           FILES=$(curl -s -X GET -G $URL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '.[] | .filename')
+
+          # Check if CRDs are modified in charts or config or both.
+          # Unfortunately we cannot overwrite contributor's changes
+          # using the update-pull-request-action, so if
+          # both CRDs are changed and not equal, we fail the workflow
+          # and post a comment on the PR informing the contributor
+          # that the CRDs must be identical.
 
           changed_config=$( (echo $FILES | grep -q -E "${CONFIG_DIR}/[[:graph:]]*\.yaml" && echo true) || echo false )
           changed_charts=$( (echo $FILES | grep -q -E "${CHARTS_DIR}/[[:graph:]]*\.yaml" && echo true) || echo false )
@@ -75,17 +79,17 @@ jobs:
           fi
 
       - name: Copy changed config CRDs to chart
-        if: ${{ steps.which-crd-modified.outputs.result == 'config' }}
+        if: ${{ steps.which-crd-modified.outputs.result == 'config' && !github.event.pull_request.head.repo.fork }}
         run: |
           cp ${CONFIG_DIR}/*.yaml ${CHARTS_DIR}
 
       - name: Copy changed chart CRDs to config
-        if: ${{ steps.which-crd-modified.outputs.result == 'charts' }}
+        if: ${{ steps.which-crd-modified.outputs.result == 'charts' && !github.event.pull_request.head.repo.fork }}
         run: |
           cp ${CHARTS_DIR}/*.yaml ${CONFIG_DIR}
 
       - name: Verify both CRDs are the same
-        if: ${{ steps.which-crd-modified.outputs.result == 'both' }}
+        if: ${{ steps.which-crd-modified.outputs.result == 'both' || github.event.pull_request.head.repo.fork }}
         run: |
           for config_file in $CONFIG_DIR/*.yaml; do
             chart_file=$CHARTS_DIR/$(basename $config_file)
@@ -96,18 +100,18 @@ jobs:
           done
 
       - name: Update pull request with synced CRDs
-        if: ${{ steps.which-crd-modified.outputs.result != 'both' }}
+        if: ${{ steps.which-crd-modified.outputs.result != 'both' && !github.event.pull_request.head.repo.fork }}
         uses: gr2m/create-or-update-pull-request-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           branch: ${{ github.head_ref }}
           path: "."
-          commit-message: "Sync CRDs in config and charts directories from commit ${{ github.sha }}"
+          commit-message: "Sync CRDs in config and charts directories from commit ${{ github.event.pull_request.merge_commit_sha }}"
           author: "${{ env.GITHUB_USER_NAME }} <${{ env.GITHUB_USER_EMAIL }}>"
 
       - name: Comment on pull request that CRDs were synced
-        if: ${{ steps.which-crd-modified.outputs.result != 'both' }}
+        if: ${{ steps.which-crd-modified.outputs.result != 'both' && !github.event.pull_request.head.repo.fork }}
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: 'Detected different CRDs in the `config/crd/bases` directory and `charts/aws-pca-issuer/crds` directory. These CRDs have been synced and the commit has been added to this PR for review.'

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,54 @@
+# workflows to sync certain files when changes are pushed to the master branch
+name: Sync
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'README.md'
+      - 'config/crd/bases/**.yaml'
+
+env:
+  GITHUB_USER_NAME: github-actions
+  GITHUB_USER_EMAIL: github-actions@github.com
+  GH_PAGES_BRANCH: gh-pages
+
+jobs:
+  sync-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.GH_PAGES_BRANCH }}
+      - name: Push README to gh-pages branch
+        run: |
+          git config user.name "$GITHUB_USER_NAME"
+          git config user.email "$GITHUB_USER_EMAIL"
+          git fetch -a
+          git checkout $GITHUB_SHA -- README.md
+          mv README.md index.md
+          git add index.md README.md
+          if git commit -m "Sync readme from commit $GITHUB_SHA"; then
+            git push origin $GH_PAGES_BRANCH
+          else
+            echo "Nothing committed, not pushing."
+          fi
+
+  sync-crds:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Copy CRDs to helm chart and push
+        run: |
+          git config user.name "$GITHUB_USER_NAME"
+          git config user.email "$GITHUB_USER_EMAIL"
+          cp config/crd/bases/*.yaml charts/aws-pca-issuer/crds/
+          git add charts
+          if git commit -m "Sync CRDs from config to charts from commit $GITHUB_SHA"; then
+            git push origin master
+          else
+            echo "Nothing committed, not pushing"
+          fi

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,4 +1,3 @@
-# workflows to sync certain files when changes are pushed to the master branch
 name: Sync
 
 on:
@@ -7,15 +6,23 @@ on:
       - 'master'
     paths:
       - 'README.md'
+  pull_request:
+    branches:
+      - 'master'
+    paths:
       - 'config/crd/bases/**.yaml'
+      - 'charts/aws-pca-issuer/crds/**.yaml'
 
 env:
   GITHUB_USER_NAME: github-actions
   GITHUB_USER_EMAIL: github-actions@github.com
   GH_PAGES_BRANCH: gh-pages
+  CONFIG_DIR: config/crd/bases
+  CHARTS_DIR: charts/aws-pca-issuer/crds
 
 jobs:
   sync-readme:
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -36,19 +43,81 @@ jobs:
             echo "Nothing committed, not pushing."
           fi
 
+  # Check if CRDs are modified in charts or config or both.
+  # Unfortunately we cannot overwrite contributor's changes
+  # using the update-pull-request-action, so we check which
+  # CRDs were changed and copy those over the unchanged CRDs.
+  # If both CRDs are changed and not equal, we fail the workflow
+  # and post a comment on the PR informing the contributor
+  # that the CRDs must be identical.
   sync-crds:
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Copy CRDs to helm chart and push
+
+      - name: Check which CRDs are modified
+        id: which-crd-modified
         run: |
-          git config user.name "$GITHUB_USER_NAME"
-          git config user.email "$GITHUB_USER_EMAIL"
-          cp config/crd/bases/*.yaml charts/aws-pca-issuer/crds/
-          git add charts
-          if git commit -m "Sync CRDs from config to charts from commit $GITHUB_SHA"; then
-            git push origin master
+          URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
+          FILES=$(curl -s -X GET -G $URL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '.[] | .filename')
+
+          changed_config=$( (echo $FILES | grep -q -E "${CONFIG_DIR}/[[:graph:]]*\.yaml" && echo true) || echo false )
+          changed_charts=$( (echo $FILES | grep -q -E "${CHARTS_DIR}/[[:graph:]]*\.yaml" && echo true) || echo false )
+
+          if $changed_config && ! $changed_charts; then
+            echo "::set-output name=result::config"
+          elif $changed_charts && ! $changed_config; then
+            echo "::set-output name=result::charts"
           else
-            echo "Nothing committed, not pushing"
+            echo "::set-output name=result::both"
           fi
+
+      - name: Copy changed config CRDs to chart
+        if: ${{ steps.which-crd-modified.outputs.result == 'config' }}
+        run: |
+          cp ${CONFIG_DIR}/*.yaml ${CHARTS_DIR}
+
+      - name: Copy changed chart CRDs to config
+        if: ${{ steps.which-crd-modified.outputs.result == 'charts' }}
+        run: |
+          cp ${CHARTS_DIR}/*.yaml ${CONFIG_DIR}
+
+      - name: Verify both CRDs are the same
+        if: ${{ steps.which-crd-modified.outputs.result == 'both' }}
+        run: |
+          for config_file in $CONFIG_DIR/*.yaml; do
+            chart_file=$CHARTS_DIR/$(basename $config_file)
+            if ! diff $config_file $chart_file; then
+              echo "${config_file} and ${chart_file} are different"
+              exit 1
+            fi
+          done
+
+      - name: Update pull request with synced CRDs
+        if: ${{ steps.which-crd-modified.outputs.result != 'both' }}
+        uses: gr2m/create-or-update-pull-request-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: ${{ github.head_ref }}
+          path: "."
+          commit-message: "Sync CRDs in config and charts directories from commit ${{ github.sha }}"
+          author: "${{ env.GITHUB_USER_NAME }} <${{ env.GITHUB_USER_EMAIL }}>"
+
+      - name: Comment on pull request that CRDs were synced
+        if: ${{ steps.which-crd-modified.outputs.result != 'both' }}
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: 'Detected different CRDs in the `config/crd/bases` directory and `charts/aws-pca-issuer/crds` directory. These CRDs have been synced and the commit has been added to this PR for review.'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on pull request that CRDs were unable to be synced
+        if: ${{ failure() }}
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: |
+            Detected different CRDs in the `config/crd/bases` directory and `charts/aws-pca-issuer/crds` directory. 
+            Since both CRDs were modified in this commit(s), they were unable to be automatically synced. Please update the pull request with identical CRDs for this workflow to pass.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There are two sets of files that need to be synchronized in different
places.

First is the README. The primary website for the plugin is hosted here
on GitHub pages: https://cert-manager.github.io/aws-privateca-issuer/
and this page is represented by the `index.md` file on the gh-pages
branch. This file should be consistent with the contents of `README.md`
on the master branch to make sure customers see the latest information.

Second is the CRDs (Custom Resource Definitions). We define CRDs in the
config/crd/bases/ directory. However, when we publish charts to helm, we
publish the CRDs located in the charts/aws-pca-issuer/crds directory. In
order to ensure customers are getting the latest custom resources we
need to copy the CRDs in the config directory to the chart directory.

Signed-off-by: Abhishek Mishra <mibhi@amazon.com>