### PR TITLE
Change BlankEndEntityCertificate_CSRPassthrough -> BlankEndEntityCert…

### DIFF
--- a/pkg/aws/pca.go
+++ b/pkg/aws/pca.go
@@ -200,7 +200,7 @@ func templateArn(caArn string, spec cmapi.CertificateRequestSpec) string {
 		}
 	}
 
-	return prefix + "acm-pca:::template/BlankEndEntityCertificate_CSRPassthrough/V1"
+	return prefix + "acm-pca:::template/BlankEndEntityCertificate_APICSRPassthrough/V1"
 }
 
 func splitRootCACertificate(caCertChainPem []byte) ([]byte, []byte, error) {

--- a/pkg/aws/pca_test.go
+++ b/pkg/aws/pca_test.go
@@ -241,7 +241,7 @@ func TestPCATemplateArn(t *testing.T) {
 			},
 		},
 		"other": {
-			expectedSuffix: ":acm-pca:::template/BlankEndEntityCertificate_CSRPassthrough/V1",
+			expectedSuffix: ":acm-pca:::template/BlankEndEntityCertificate_APICSRPassthrough/V1",
 			keyUsages: []v1.KeyUsage{
 				v1.UsageTimestamping,
 			},


### PR DESCRIPTION
…ificate_APICSRPassthrough for the default case

Signed-off-by: Divyansh Gupta <guptadiv@amazon.com>

Explanation: Currently, AWS Private CA only allow certain certificate templates to be issued cross-account:
* EndEntityCertificate/V1
* EndEntityClientAuthCertificate/V1
* EndEntityServerAuthCertificate/V1
* BlankEndEntityCertificate_APICSRPassthrough

The default template in the this plugin is `acm-pca:::template/BlankEndEntityCertificate_CSRPassthrough/V1`. Notice how that is not one of the supported templates above for cross account. This means that the cross-account case is not supported with default options - you have to specify values. This PR changes the default template in the k8s plugin to a supported cross-account template, to solve the issue: `acm-pca:::template/BlankEndEntityCertificate_APICSRPassthrough/V1`