### PR TITLE
Test with cert-manager 1.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ KIND := ${BIN}/kind-${KIND_VERSION}
 K8S_CLUSTER_NAME := pca-external-issuer
 
 # cert-manager
-CERT_MANAGER_VERSION ?= 1.3.0
+CERT_MANAGER_VERSION ?= 1.7.0
 
 # Controller tools
 CONTROLLER_GEN_VERSION := 0.5.0


### PR DESCRIPTION
cert-manager 1.7.0 was released yesterday so I've update the Makefile to run cert-manager v1.7.0 in the E2E tests.

The tests seem to pass.

Feel free to close this PR if you prefer to test with a minimum supported version of cert-manager.

Or perhaps we can figure out a nice way to test this (and other external issuers) with multiple cert-manager versions.