### PR TITLE
overridden durations should be specified from epoch

### DIFF
--- a/pkg/aws/pca.go
+++ b/pkg/aws/pca.go
@@ -99,7 +99,7 @@ func (p *PCAProvisioner) Sign(ctx context.Context, cr *cmapi.CertificateRequest,
 
 	validityExpiration := int64(time.Now().Unix()) + 30*24*3600
 	if cr.Spec.Duration != nil {
-		validityExpiration += int64(cr.Spec.Duration.Hours()) * 3600
+		validityExpiration = int64(time.Now().Unix()) + int64(cr.Spec.Duration.Seconds())
 	}
 
 	tempArn := templateArn(p.arn, cr.Spec)


### PR DESCRIPTION
Overridden durations should be specified from epoch https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_Validity.html

Apologies if i'm miss understanding this. It looks like there was an update previously https://github.com/cert-manager/aws-privateca-issuer/pull/70 that would set certificates that specified duration as being in addition to the default i.e 30 days + whatever duration.

I think what people are expecting is that durations are set from issuance.
