### PR TITLE
Use appVersion as the default image tag

### DIFF
--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: public.ecr.aws/k1n1h4h4/cert-manager-aws-privateca-issuer
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  # tag: "latest"
 
 # Disable waiting for CertificateRequests to be Approved before signing
 disableApprovedCheck: false


### PR DESCRIPTION
This is mostly configured already, but since `image.tag` was always set
to "latest" in the values.yaml, that became the default value, instead
of the app version.