### PR TITLE
Use appVersion as the default image tag (follow-up)

### DIFF
--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -5,8 +5,6 @@ replicaCount: 1
 image:
   repository: public.ecr.aws/k1n1h4h4/cert-manager-aws-privateca-issuer
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
 
 # Disable waiting for CertificateRequests to be Approved before signing
 disableApprovedCheck: false


### PR DESCRIPTION
This is mostly configured already, but since `image.tag` was always set
to "latest" in the values.yaml, that became the default value, instead
of the app version.

This is a follow-up to Sarah Hodne's PR Here:
https://github.com/cert-manager/aws-privateca-issuer/pull/126
where we simply remove the line instead of commenting it out.

Signed-off-by: Hamidhasan Ahmed <hamidhaa@amazon.com>