### PR TITLE
Add namespace for all namespaced resources

### DIFF
--- a/charts/aws-pca-issuer/templates/deployment.yaml
+++ b/charts/aws-pca-issuer/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "aws-privateca-issuer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-privateca-issuer.labels" . | nindent 4 }}
 spec:

--- a/charts/aws-pca-issuer/templates/hpa.yaml
+++ b/charts/aws-pca-issuer/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "aws-privateca-issuer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-privateca-issuer.labels" . | nindent 4 }}
 spec:
@@ -10,6 +11,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "aws-privateca-issuer.fullname" . }}
+    namespace: {{ .Release.Namespace }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/charts/aws-pca-issuer/templates/rbac.yaml
+++ b/charts/aws-pca-issuer/templates/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "aws-privateca-issuer.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-privateca-issuer.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/aws-pca-issuer/templates/service-monitor.yaml
+++ b/charts/aws-pca-issuer/templates/service-monitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "aws-privateca-issuer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-privateca-issuer.labels" . | nindent 4 }}
   {{- with .Values.serviceMonitor.annotations }}

--- a/charts/aws-pca-issuer/templates/service.yaml
+++ b/charts/aws-pca-issuer/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "aws-privateca-issuer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-privateca-issuer.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Currently, the service account has a namespace specified. If the release namespace is not the default namespace, the deployment will be created in a different namespace than the service account, making the pod creation fail. 

This commit adds `namespace` for all namespaced resources in the chart. 

TESTED: Manually tested with `helm install` in the `cert-manager` namespace. 


Signed-off-by: lorqor <lorqor@gmail.com>