### PR TITLE
Remove dependency dashboard (again)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,16 +2,15 @@
     "extends": [
         ":automergeDisabled",
         "config:base",
-        ":disableDependencyDashboard",
         ":gitSignOff"
     ],
+    "dependencyDashboard": false,
     "ignorePaths" : [
         "config/manager/kustomization.yaml",
         ".github/workflows/on-push-to-main-branch.yml",
         ".github/workflows/on-release.yml",
         ".github/workflows/sync.yml"
     ],
-    "masterIssue": true,
     "packageRules": [{
         "matchPackagePatterns": [
             "*"


### PR DESCRIPTION
- For some reason using `:disableDependencyDashboard` in `renovate.json`
  did not remove the dependency dashboard issue
- According to renovate docs `config:base` has the `:dependencyDashboard` as a preset, which is why `:disableDependencyDashboard` wasn't working.
- Added `dependencyDashboard: false` to `renovate.json`
- Removed `masterIssue: false` from `renovate.json`. Not sure why I had this config in there...
- If this doesn't remove it, I will cut an issue to renovate