### PR TITLE
Changed Renovate Schedule to Wednesday, fixed commit message suffix/prefix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,12 +44,13 @@
   ],
   "vulnerabilityAlerts": {
     "schedule": [],
-    "commitMessagePrefix": ["[SECURITY]"],
+    "commitMessagePrefix": "[SECURITY]",
+    "commitMessageSuffix": "",
     "automerge": false
   },
   "schedule": [
-    "after 9am on Monday",
-    "before 12pm on Monday"
+    "after 9am on Wednesday",
+    "before 12pm on Wednesday"
   ],
   "timezone": "America/New_York"
 }


### PR DESCRIPTION
- Since oncall switches on Tuesday, it makes more sense for dep updates
  to be Wednesday, so it's once per oncall rotation
- Commit message suffix is set to '[SECURITY]' by default, so we want to
  switch that to nothing so it's only prefixed by '[SECURITY]'
- Commit message suffix/prefix is string typed, so removed the
  surrounding brackets of prefix

Signed-off-by: Brady Siegel <brsiegel@amazon.com>