### PR TITLE
Change GOVERSION to 1.19

### DIFF
--- a/.github/workflows/on-safe-to-test-label.yml
+++ b/.github/workflows/on-safe-to-test-label.yml
@@ -79,7 +79,7 @@ jobs:
           mkdir /home/ec2-user/.cache/go-mod
           mkdir /home/ec2-user/go
           mkdir /home/ec2-user/go/bin
-          GOVERSION=go1.19.0
+          GOVERSION=go1.19
           wget https://go.dev/dl/$GOVERSION.linux-amd64.tar.gz
           sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf $GOVERSION.linux-amd64.tar.gz
           PATH="$PATH:/usr/local/go/bin"


### PR DESCRIPTION
Google's download link doesn't include patch version when it's .0. Fixing this to make sure it doesn't bite us in testing. I cut them an issue on the go repo

Signed-off-by: Brady Siegel <brsiegel@amazon.com>