### PR TITLE
Change golang versioning type to docker

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,7 +39,9 @@
       "fileMatch": ["^.github/workflows/on-safe-to-test-label.yml$"],
       "matchStrings": ["GOVERSION=go(?<currentValue>.*?)\\n"],
       "depNameTemplate": "golang",
-      "datasourceTemplate": "docker"
+      "depTypeTemplate": "stage",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
   ],
   "vulnerabilityAlerts": {

--- a/.github/workflows/on-safe-to-test-label.yml
+++ b/.github/workflows/on-safe-to-test-label.yml
@@ -79,7 +79,7 @@ jobs:
           mkdir /home/ec2-user/.cache/go-mod
           mkdir /home/ec2-user/go
           mkdir /home/ec2-user/go/bin
-          GOVERSION=go1.19.0
+          GOVERSION=go1.19
           wget https://go.dev/dl/$GOVERSION.linux-amd64.tar.gz
           sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf $GOVERSION.linux-amd64.tar.gz
           PATH="$PATH:/usr/local/go/bin"


### PR DESCRIPTION
Google's golang download link doesn't include the patch version if it's zero. To deal with this, we switched the version of the golang dependency in on-safe-to-test-label.yml to docker versioning (major.minor), which will allow us to always contact a working go download link.

Signed-off-by: Brady Siegel <brsiegel@amazon.com>