### PR TITLE
Update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,9 +11,6 @@
     ".github/workflows/on-release.yml",
     ".github/workflows/sync.yml"
   ],
-  "ignoreDeps": [
-    "k8s.io/client-go"
-  ],
   "packageRules": [{
     "matchPackagePatterns": [
       "*"
@@ -25,6 +22,16 @@
     ],
     "groupName": "all non-major dependencies",
     "groupSlug": "all-minor-patch"
+  }, {
+    "matchPackageNames": [
+      "k8s.io/client-go",
+      "k8s.io/api",
+      "k8s.io/apimachinery"
+    ],
+    "matchUpdateTypes": [
+      "major" 
+    ],
+    "enabled": false
   }],
   "prConcurrentLimit": 3,
   "prHourlyLimit": 1,


### PR DESCRIPTION
k8s.io needs to be updated in tandem. We previously ignored k8s.io/client-go, but this introduced a dependency version mismatch. This change will ignore all major updates from these three packages so we only get the 0.* updates.

Signed-off-by: Brady Siegel <brsiegel@amazon.com>