### PR TITLE
Fixes whitespace lint error

### DIFF
--- a/charts/aws-pca-issuer/templates/rbac.yaml
+++ b/charts/aws-pca-issuer/templates/rbac.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 {{- end }}
 ---
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
Closes #212

This dash was causing a whitespace problem which causes `helm lint` to fail. 

Before
```
$ helm lint awspca/aws-privateca-issuer

==> Linting awspca/aws-privateca-issuer
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/rbac.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: rbac.authorization.k8s.io/v1

Error: 1 chart(s) linted, 1 chart(s) failed
```

After 
```
$ helm lint awspca/aws-privateca-issuer

==> Linting awspca/aws-privateca-issuer
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed

Error: 1 chart(s) linted, 0 chart(s) failed
```

Signed-off-by: Kevin <kevin@stealsyour.pw>