### PR TITLE
Change VERSION creation command to fetch tags from main repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # The version which will be reported by the --version argument of each binary
 # and which will be used as the Docker image tag
-VERSION ?= $(shell git describe --tags | awk -F"-" '{print $$1}')
+VERSION := $(shell git remote add mainRepo https://github.com/cert-manager/aws-privateca-issuer.git && git fetch mainRepo --tags && git describe --tags | awk -F"-" '{print $$1}' && git remote remove mainRepo)
 
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)


### PR DESCRIPTION
- When customers fork, they don't always have the tags in their repo. This was causing test failures because the git describe --tags command was failing
- To solve this, let's add our repo as an upstream and describe tags from there, and then cleanup after getting the information we need

Signed-off-by: Brady Siegel <brsiegel@amazon.com>