### PR TITLE
fix(helm-chart): append 'v' if using default value for image.

### DIFF
--- a/charts/aws-pca-issuer/templates/deployment.yaml
+++ b/charts/aws-pca-issuer/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default ( printf "v%s" .Chart.AppVersion )}}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /manager

--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -5,6 +5,7 @@ replicaCount: 1
 image:
   repository: public.ecr.aws/k1n1h4h4/cert-manager-aws-privateca-issuer
   pullPolicy: IfNotPresent
+  tag: ""
 
 # Disable waiting for CertificateRequests to be Approved before signing
 disableApprovedCheck: false


### PR DESCRIPTION
Currently the image definition of the operator deployment is missing the leading 'v'.    
This leads to ImagePullBackOff errors if using the default value which is supplied by the AppVersion field. 

Signed-off-by: secustor <sebastian@poxhofer.at>