### PR TITLE
fix(helm-chart): Remove extra 'v' from Image

### DIFF
--- a/charts/aws-pca-issuer/templates/deployment.yaml
+++ b/charts/aws-pca-issuer/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default ( printf "v%s" .Chart.AppVersion )}}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /manager


### PR DESCRIPTION
https://github.com/cert-manager/aws-privateca-issuer/pull/227/files caused an issue in release 1.2.3 (https://github.com/cert-manager/aws-privateca-issuer/issues/231) where two v's are appended to the image, causing `ErrImagePull`.

Signed-off-by: Divyansh Gupta <guptadiv@amazon.com>