### PR TITLE
fix(helm-chart): sync outdated CRDs

### DIFF
--- a/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaclusterissuers.yaml
+++ b/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaclusterissuers.yaml
@@ -47,6 +47,25 @@ spec:
                 description: Needs to be specified if you want to authorize with AWS
                   using an access and secret key
                 properties:
+                  accessKeyIDSelector:
+                    description: Specifies the secret key where the AWS Access Key
+                      ID exists
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
                   name:
                     description: Name is unique within a namespace to reference a
                       secret resource.
@@ -55,6 +74,25 @@ spec:
                     description: Namespace defines the space within which the secret
                       name must be unique.
                     type: string
+                  secretAccessKeySelector:
+                    description: Specifies the secret key where the AWS Secret Access
+                      Key exists
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
                 type: object
             type: object
           status:

--- a/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaissuers.yaml
+++ b/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaissuers.yaml
@@ -46,6 +46,25 @@ spec:
                 description: Needs to be specified if you want to authorize with AWS
                   using an access and secret key
                 properties:
+                  accessKeyIDSelector:
+                    description: Specifies the secret key where the AWS Access Key
+                      ID exists
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
                   name:
                     description: Name is unique within a namespace to reference a
                       secret resource.
@@ -54,6 +73,25 @@ spec:
                     description: Namespace defines the space within which the secret
                       name must be unique.
                     type: string
+                  secretAccessKeySelector:
+                    description: Specifies the secret key where the AWS Secret Access
+                      Key exists
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
                 type: object
             type: object
           status:


### PR DESCRIPTION
The CRDs included in helm chart are outdated. 
I just copied /config/crd/bases/* to /charts/aws-pca-issuer/crds/