### PR TITLE
Prepend 'v' to version and appVersion in Chart.yaml

### DIFF
--- a/charts/aws-pca-issuer/Chart.yaml
+++ b/charts/aws-pca-issuer/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: aws-privateca-issuer
 description: An addon for cert-manager to sign certificates using AWS PCA
 type: application
-version: 1.2.4
-appVersion: 1.2.4
+version: v1.2.4
+appVersion: v1.2.4


### PR DESCRIPTION
As described in https://github.com/cert-manager/aws-privateca-issuer/issues/243, this commit is necessary to ensure that aws-privateca-issuer pods can pull the correct image without having to specify an image tag.

Signed-off-by: Hamidhasan G. Ahmed <hamidhaa@amazon.com>