### PR TITLE
feat: allow restricting to namespace

### DIFF
--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -31,7 +31,6 @@ service:
   type: ClusterIP
   port: 8080
 
-
 # Options for configuring a target ServiceAccount with the role to approve
 # all awspca.cert-manager.io requests.
 approverRole:

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func init() {
 
 func main() {
 	var metricsAddr string
+	var restrictToNamespace string
 	var enableLeaderElection bool
 	var probeAddr string
 	var disableApprovedCheck bool
@@ -64,6 +65,8 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&disableApprovedCheck, "disable-approved-check", false,
 		"Disables waiting for CertificateRequests to have an approved condition before signing.")
+	flag.StringVar(&restrictToNamespace, "restrict-to-namespace", os.Getenv("RESTRICT_TO_NAMESPACE"), 
+		"Restrict the controller to only process CertificateRequests in a specific namespace.")
 
 	opts := zap.Options{
 		Development: false,
@@ -80,6 +83,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "b858308c.awspca.cert-manager.io",
+		Namespace:              restrictToNamespace,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
This PR adds the possibility to restrict to listening only to specific namespaces. This is required if you use IAM role for service account. Otherwise this would allow you to create any AWSPCAIssuer in any namespace and resolve that with the controllers permission.

See: https://sdk.operatorframework.io/docs/building-operators/golang/operator-scope/#watching-resources-in-a-single-namespace