### PR TITLE
feat(helm): configure deployment revisionHistoryLimit

### DIFF
--- a/charts/aws-pca-issuer/templates/deployment.yaml
+++ b/charts/aws-pca-issuer/templates/deployment.yaml
@@ -9,6 +9,7 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "aws-privateca-issuer.selectorLabels" . | nindent 6 }}

--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -14,6 +14,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+revisionHistoryLimit: 10
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Applies a fix to https://github.com/cert-manager/aws-privateca-issuer/pull/248 that moves the revisionHistoryLimit to `.spec` instead of `.spec.template`. Thank you @woehrl01 for the contribution!