### PR TITLE
Use the Docker Build Kit platform vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM golang:1.20 as builder
 WORKDIR /workspace
 
+ARG TARGETARCH=amd64
+ARG TARGETOS=linux
+
 ENV GOPROXY=direct
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -15,8 +18,8 @@ COPY main.go main.go
 COPY pkg/ pkg/
 
 ENV CGO_ENABLED=0
-ENV GOOS=linux
-ENV GOARCH=amd64
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
 ENV GO111MODULE=on
 
 # Do an initial compilation before setting the version so that there is less to


### PR DESCRIPTION
The Docker Build Kit exports the target OS and architecture as build args so we can use them instead of assuming linux/amd64.  The default values are set to `linux/amd64` in case you are building in a docker version that does not have build kit available.  You may also need to set `DOCKER_BUILDKIT=1` for it to export `TARGETOS` and `TARGETARCH` correctly.

I'm not sure what incantations are required in the Github actions to build on ARM as well as Intel but this should "just work" if you are building on an ARM CPU.  This is a start to addressing #147 though additional CI work is required.

https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope