### PR TITLE
Add support of priorityClassName to the helm chart

### DIFF
--- a/charts/aws-pca-issuer/templates/deployment.yaml
+++ b/charts/aws-pca-issuer/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "aws-privateca-issuer.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -50,6 +50,9 @@ podAnnotations: {}
 podSecurityContext:
   runAsUser: 65532
 
+# priorityClassName defines the PriorityClass to be used by the operator pods.
+priorityClassName: ""
+
 securityContext:
   allowPrivilegeEscalation: false
 


### PR DESCRIPTION
The current helm chart doesn't support setting `priorityClassName` for the operator pods. By this PR, users can set `priorityClassName` as a helm value to be used by the operator.