### PR TITLE
fix: HPA syntax, allow v2 API

### DIFF
--- a/charts/aws-pca-issuer/Chart.yaml
+++ b/charts/aws-pca-issuer/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: aws-privateca-issuer
 description: An addon for cert-manager to sign certificates using AWS PCA
 type: application
-version: v1.2.5
+version: v1.2.6
 appVersion: v1.2.5

--- a/charts/aws-pca-issuer/templates/hpa.yaml
+++ b/charts/aws-pca-issuer/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+apiVersion: autoscaling/v2
+{{- else }}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "aws-privateca-issuer.fullname" . }}
@@ -11,7 +15,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "aws-privateca-issuer.fullname" . }}
-    namespace: {{ .Release.Namespace }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:


### PR DESCRIPTION
HPA had apparently an additional field (checked v1 and v2 and none have `namespace` under scaleTargetRef.
Support for HPA v2 added if supported by the target cluster.