### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/on-safe-to-test-label.yml
+++ b/.github/workflows/on-safe-to-test-label.yml
@@ -92,9 +92,10 @@ jobs:
           echo PATH=$PATH >> $GITHUB_ENV
       - name: Setup Cache variables
         id: go-cache-paths
+        shell: bash
         run: |
-          echo "::set-output name=go-build::${{ env.GOCACHE }}"
-          echo "::set-output name=go-mod::${{ env.GOMODCACHE }}"
+          echo "go-build=${{ env.GOCACHE }}" >> $GITHUB_OUTPUT
+          echo "go-mod=${{ env.GOMODCACHE }}" >> $GITHUB_OUTPUT
       - name: Go-Build Cache # Cache go build cache, used to speedup go test
         uses: actions/cache@v3
         with:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -71,11 +71,11 @@ jobs:
           changed_charts=$( (echo $FILES | grep -q -E "${CHARTS_DIR}/[[:graph:]]*\.yaml" && echo true) || echo false )
 
           if $changed_config && ! $changed_charts; then
-            echo "::set-output name=result::config"
+            echo "result=config" >> $GITHUB_OUTPUT
           elif $changed_charts && ! $changed_config; then
-            echo "::set-output name=result::charts"
+            echo "result=charts" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=result::both"
+            echo "result=both" >> $GITHUB_OUTPUT
           fi
 
       - name: Copy changed config CRDs to chart


### PR DESCRIPTION
## Description

Closes #301 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
- name: Setup Cache variables
  id: go-cache-paths
  run: |
    echo "::set-output name=go-build::${{ env.GOCACHE }}"
    echo "::set-output name=go-mod::${{ env.GOMODCACHE }}"
```

**TO-BE**

```yaml
- name: Setup Cache variables
  id: go-cache-paths
  shell: bash
  run: |
    echo "go-build=${{ env.GOCACHE }}" >> $GITHUB_OUTPUT
    echo "go-mod=${{ env.GOMODCACHE }}" >> $GITHUB_OUTPUT
```