### PR TITLE
Upgrade hpa to api version v2 for k8s 1.26

### DIFF
--- a/charts/aws-pca-issuer/templates/hpa.yaml
+++ b/charts/aws-pca-issuer/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "aws-privateca-issuer.fullname" . }}
@@ -11,9 +11,12 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "aws-privateca-issuer.fullname" . }}
-    namespace: {{ .Release.Namespace }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource

--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -61,7 +61,8 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
-
+  behavior: {}
+  
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Updates the version of HPA in chart to use api v2