### PR TITLE
feat: add autogenerated helm docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ CERT_MANAGER_VERSION ?= v1.13.3
 CONTROLLER_GEN_VERSION := 0.5.0
 CONTROLLER_GEN := ${BIN}/controller-gen-${CONTROLLER_GEN_VERSION}
 
+# Helm tools
+HELM_TOOL_VERSION := v0.2.2
+
 INSTALL_YAML ?= build/install.yaml
 
 all: manager
@@ -114,6 +117,9 @@ undeploy:
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
+helm-docs: helm-tool
+	$(HELM_TOOL) inject -i charts/aws-pca-issuer/values.yaml -o charts/aws-pca-issuer/README.md --header-search "^<!-- AUTO-GENERATED -->" --footer-search "<!-- /AUTO-GENERATED -->"
+
 # Run go fmt against code
 fmt:
 	go fmt ./...
@@ -148,6 +154,10 @@ docker-push:
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen:
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
+
+HELM_TOOL = $(shell pwd)/bin/helm-tool
+helm-tool:
+	$(call go-install-tool,$(HELM_TOOL),github.com/cert-manager/helm-tool@$(HELM_TOOL_VERSION))
 
 # Download kustomize locally if necessary
 KUSTOMIZE = $(shell pwd)/bin/kustomize

--- a/charts/aws-pca-issuer/README.md
+++ b/charts/aws-pca-issuer/README.md
@@ -1,0 +1,791 @@
+# AWS Private CA Issuer
+
+AWS Private CA is an AWS service that can setup and manage private CAs, as well as issue private certifiates.
+
+cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
+It will ensure certificates are valid and up to date periodically, and attempt to renew certificates at an appropriate time before expiry.
+
+This project acts as an addon (see https://cert-manager.io/docs/configuration/external/) to cert-manager that signs off certificate requests using AWS Private CA.
+
+## Values
+
+<!-- AUTO-GENERATED -->
+
+### AWS Private CA Issuer
+
+
+<table>
+<tr>
+<th>Property</th>
+<th>Description</th>
+<th>Type</th>
+<th>Default</th>
+</tr>
+<tr>
+
+<td>replicaCount</td>
+<td>
+
+Number of replicas to run of the issuer
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+1
+```
+
+</td>
+</tr>
+<tr>
+
+<td>image.repository</td>
+<td>
+
+Image repository
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+public.ecr.aws/k1n1h4h4/cert-manager-aws-privateca-issuer
+```
+
+</td>
+</tr>
+<tr>
+
+<td>image.pullPolicy</td>
+<td>
+
+Image pull policy
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+IfNotPresent
+```
+
+</td>
+</tr>
+<tr>
+
+<td>image.tag</td>
+<td>
+
+Image tag
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+""
+```
+
+</td>
+</tr>
+<tr>
+
+<td>disableApprovedCheck</td>
+<td>
+
+Disable waiting for CertificateRequests to be Approved before signing
+
+</td>
+<td>bool</td>
+<td>
+
+```yaml
+false
+```
+
+</td>
+</tr>
+<tr>
+
+<td>imagePullSecrets</td>
+<td>
+
+Optional secrets used for pulling the container image  
+  
+For example:
+
+```yaml
+imagePullSecrets:
+- name: secret-name
+```
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+[]
+```
+
+</td>
+</tr>
+<tr>
+
+<td>nameOverride</td>
+<td>
+
+Override the name of the objects created by this chart
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+""
+```
+
+</td>
+</tr>
+<tr>
+
+<td>fullnameOverride</td>
+<td>
+
+Override the name of the objects created by this chart
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+""
+```
+
+</td>
+</tr>
+<tr>
+
+<td>revisionHistoryLimit</td>
+<td>
+
+Number deployment revisions to keep
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+10
+```
+
+</td>
+</tr>
+<tr>
+
+<td>serviceAccount.create</td>
+<td>
+
+Specifies whether a service account should be created
+
+</td>
+<td>bool</td>
+<td>
+
+```yaml
+true
+```
+
+</td>
+</tr>
+<tr>
+
+<td>serviceAccount.annotations</td>
+<td>
+
+Annotations to add to the service account
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>serviceAccount.name</td>
+<td>
+
+The name of the service account to use.  
+If not set and create is true, a name is generated using the fullname template
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+""
+```
+
+</td>
+</tr>
+<tr>
+
+<td>rbac.create</td>
+<td>
+
+Specifies whether RBAC should be created
+
+</td>
+<td>bool</td>
+<td>
+
+```yaml
+true
+```
+
+</td>
+</tr>
+<tr>
+
+<td>service.type</td>
+<td>
+
+Type of service to create
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+ClusterIP
+```
+
+</td>
+</tr>
+<tr>
+
+<td>service.port</td>
+<td>
+
+Port the service should listen on
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+8080
+```
+
+</td>
+</tr>
+<tr>
+
+<td>podAnnotations</td>
+<td>
+
+Annotations to add to the issuer Pod
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>podSecurityContext</td>
+<td>
+
+Pod security context
+
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+runAsUser: 65532
+```
+
+</td>
+</tr>
+<tr>
+
+<td>securityContext</td>
+<td>
+
+Container security context
+
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+allowPrivilegeEscalation: false
+```
+
+</td>
+</tr>
+<tr>
+
+<td>resources</td>
+<td>
+
+Kubernetes pod resources requests/limits  
+  
+For example:
+
+```yaml
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+```
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>nodeSelector</td>
+<td>
+
+Kubernetes node selector: node labels for pod assignment
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>tolerations</td>
+<td>
+
+Kubernetes pod tolerations for cert-manager-csi-driver  
+  
+For example:
+
+```yaml
+tolerations:
+- operator: "Exists"
+```
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+[]
+```
+
+</td>
+</tr>
+<tr>
+
+<td>affinity</td>
+<td>
+
+A Kubernetes Affinity, if required; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core  
+  
+For example:
+
+```yaml
+affinity:
+  nodeAffinity:
+   requiredDuringSchedulingIgnoredDuringExecution:
+     nodeSelectorTerms:
+     - matchExpressions:
+       - key: foo.bar.com/role
+         operator: In
+         values:
+         - master
+```
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>topologySpreadConstraints</td>
+<td>
+
+List of Kubernetes TopologySpreadConstraints; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core  
+  
+For example:
+
+```yaml
+topologySpreadConstraints:
+- maxSkew: 1
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: ScheduleAnyway
+  labelSelector:
+    matchLabels:
+      app.kubernetes.io/name: aws-privateca-issuer
+```
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+[]
+```
+
+</td>
+</tr>
+<tr>
+
+<td>env</td>
+<td>
+
+Additional environment variables to set in the Pod
+
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+null
+```
+
+</td>
+</tr>
+<tr>
+
+<td>podLabels</td>
+<td>
+
+Additional labels to add to the Pod
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>volumes</td>
+<td>
+
+Additional volumes on the operator container.
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+[]
+```
+
+</td>
+</tr>
+<tr>
+
+<td>volumeMounts</td>
+<td>
+
+Additional VolumeMounts on the operator container.
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+[]
+```
+
+</td>
+</tr>
+<tr>
+
+<td>podDisruptionBudget</td>
+<td>
+
+Configures a disruption budget for the deployment.  
+  
+Expects input structure similar to https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#poddisruptionbudgetspec-v1-policy. WITHOUT the pod selector, which is handled by the chart. Per https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#poddisruptionbudgetspec-v1-policy, `maxUnavailable` is mutually exclusive with `minAvailable`, you cannot set both.  
+  
+For example:
+
+```yaml
+podDisruptionBudget:
+  maxUnavailable: 1
+```
+
+Or:
+
+```yaml
+podDisruptionBudget:
+  minAvailable: 1
+```
+
+But NOT:
+
+```yaml
+podDisruptionBudget:
+  minAvailable: 1
+  maxUnavailable: 1
+```
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+</table>
+
+### Autoscaling
+
+
+<table>
+<tr>
+<th>Property</th>
+<th>Description</th>
+<th>Type</th>
+<th>Default</th>
+</tr>
+<tr>
+
+<td>autoscaling.enabled</td>
+<td>
+
+Enable auto scaling using a HorizontalPodAutoscaler
+
+</td>
+<td>bool</td>
+<td>
+
+```yaml
+false
+```
+
+</td>
+</tr>
+<tr>
+
+<td>autoscaling.minReplicas</td>
+<td>
+
+Minimum number of replicas to deploy
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+1
+```
+
+</td>
+</tr>
+<tr>
+
+<td>autoscaling.maxReplicas</td>
+<td>
+
+Maximum number of replicas to deploy
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+100
+```
+
+</td>
+</tr>
+<tr>
+
+<td>autoscaling.targetCPUUtilizationPercentage</td>
+<td>
+
+CPU threshold to scale at as a percentage of the requested CPUs
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+80
+```
+
+</td>
+</tr>
+<tr>
+
+<td>autoscaling.targetMemoryUtilizationPercentage</td>
+<td>
+
+Memory threshold to scale at as a percentage of the requested memory
+
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+
+```
+
+</td>
+</tr>
+</table>
+
+### Approver Role
+
+
+Options for configuring a target ServiceAccount with the role to approve all awspca.cert-manager.io requests.
+
+<table>
+<tr>
+<th>Property</th>
+<th>Description</th>
+<th>Type</th>
+<th>Default</th>
+</tr>
+<tr>
+
+<td>approverRole.enabled</td>
+<td>
+
+Create the ClusterRole to allow the issuer to approve certificate requests
+
+</td>
+<td>bool</td>
+<td>
+
+```yaml
+true
+```
+
+</td>
+</tr>
+<tr>
+
+<td>approverRole.serviceAccountName</td>
+<td>
+
+Service account give approval permission
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+cert-manager
+```
+
+</td>
+</tr>
+<tr>
+
+<td>approverRole.namespace</td>
+<td>
+
+Namespace the service account resides in
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+cert-manager
+```
+
+</td>
+</tr>
+</table>
+
+### Monitoring
+
+
+<table>
+<tr>
+<th>Property</th>
+<th>Description</th>
+<th>Type</th>
+<th>Default</th>
+</tr>
+<tr>
+
+<td>serviceMonitor.create</td>
+<td>
+
+Create Prometheus ServiceMonitor
+
+</td>
+<td>bool</td>
+<td>
+
+```yaml
+false
+```
+
+</td>
+</tr>
+<tr>
+
+<td>serviceMonitor.annotations</td>
+<td>
+
+Annotations to add to the Prometheus ServiceMonitor
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+</table>
+
+<!-- /AUTO-GENERATED -->

--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -1,19 +1,33 @@
-# Default values for aws-pca-issuer.
+# +docs:section=AWS Private CA Issuer
 
+# Number of replicas to run of the issuer
 replicaCount: 1
 
 image:
+  # Image repository
   repository: public.ecr.aws/k1n1h4h4/cert-manager-aws-privateca-issuer
+  # Image pull policy
   pullPolicy: IfNotPresent
+  # Image tag
   tag: ""
 
 # Disable waiting for CertificateRequests to be Approved before signing
 disableApprovedCheck: false
 
+# Optional secrets used for pulling the container image
+#
+# For example:
+#  imagePullSecrets:
+#  - name: secret-name
 imagePullSecrets: []
+
+# Override the name of the objects created by this chart
 nameOverride: ""
+
+# Override the name of the objects created by this chart
 fullnameOverride: ""
 
+# Number deployment revisions to keep
 revisionHistoryLimit: 10
 
 serviceAccount:
@@ -30,47 +44,63 @@ rbac:
   create: true
 
 service:
+  # Type of service to create
   type: ClusterIP
+  # Port the service should listen on
   port: 8080
 
-
-# Options for configuring a target ServiceAccount with the role to approve
-# all awspca.cert-manager.io requests.
-approverRole:
-  enabled: true
-  serviceAccountName: cert-manager
-  namespace: cert-manager
-
-serviceMonitor:
-  create: false
-  annotations: {}
-  labels: {}
-
+# Annotations to add to the issuer Pod
 podAnnotations: {}
 
+# Pod security context 
+# +docs:property
 podSecurityContext:
   runAsUser: 65532
 
+# Container security context 
+# +docs:property
 securityContext:
   allowPrivilegeEscalation: false
 
+# Kubernetes pod resources requests/limits
+#
+# For example:
+#  resources:
+#    limits:
+#      cpu: 100m
+#      memory: 128Mi
+#    requests:
+#      cpu: 100m
+#      memory: 128Mi
 resources: {}
 
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
-
+# Kubernetes node selector: node labels for pod assignment
 nodeSelector: {}
 
+# Kubernetes pod tolerations for cert-manager-csi-driver
+#
+# For example:
+#  tolerations:
+#  - operator: "Exists"
 tolerations: []
 
+# A Kubernetes Affinity, if required; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core
+#
+# For example:
+#   affinity:
+#     nodeAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        nodeSelectorTerms:
+#        - matchExpressions:
+#          - key: foo.bar.com/role
+#            operator: In
+#            values:
+#            - master
 affinity: {}
 
-# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#topologyspreadconstraint-v1-core
-# for example:
+# List of Kubernetes TopologySpreadConstraints; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core
+#
+# For example:
 #   topologySpreadConstraints:
 #   - maxSkew: 1
 #     topologyKey: topology.kubernetes.io/zone
@@ -80,8 +110,11 @@ affinity: {}
 #         app.kubernetes.io/name: aws-privateca-issuer
 topologySpreadConstraints: []
 
+# Additional environment variables to set in the Pod
+# +docs:type=object
 env:
 
+# Additional labels to add to the Pod
 podLabels: {}
 
 # Additional volumes on the operator container.
@@ -90,21 +123,60 @@ volumes: []
 # Additional VolumeMounts on the operator container.
 volumeMounts: []
 
-# expects input structure similar to https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#poddisruptionbudgetspec-v1-policy
-# EXCEPT pod selector is defined by this helm template's `aws-privateca-issuer.selectorLabels` template function. per
-# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#poddisruptionbudgetspec-v1-policy, `maxUnavailable` is mutually
-# exclusive with `minAvailable`.  you cannot choose both.
+# Configures a disruption budget for the deployment.
 #
-# for example:
+# Expects input structure similar to https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#poddisruptionbudgetspec-v1-policy
+# WITHOUT the pod selector, which is handled by the chart. 
+# Per https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#poddisruptionbudgetspec-v1-policy, `maxUnavailable` is mutually
+# exclusive with `minAvailable`, you cannot set both.
+#
+# For example:
 #   podDisruptionBudget:
 #     maxUnavailable: 1
 #
-# or:
+# Or:
 #   podDisruptionBudget:
 #     minAvailable: 1
 #
-# but NOT:
+# But NOT:
 #   podDisruptionBudget:
 #     minAvailable: 1
 #     maxUnavailable: 1
 podDisruptionBudget: {}
+
+# +docs:section=Autoscaling
+
+autoscaling:
+  # Enable auto scaling using a HorizontalPodAutoscaler
+  enabled: false
+  # Minimum number of replicas to deploy
+  minReplicas: 1
+  # Maximum number of replicas to deploy
+  maxReplicas: 100
+  # CPU threshold to scale at as a percentage of the requested CPUs
+  targetCPUUtilizationPercentage: 80
+  # Memory threshold to scale at as a percentage of the requested memory
+  # +docs:property
+  # targetMemoryUtilizationPercentage: 80
+
+# +docs:section=Approver Role
+# Options for configuring a target ServiceAccount with the role to approve
+# all awspca.cert-manager.io requests.
+
+approverRole:
+  # Create the ClusterRole to allow the issuer to approve certificate requests
+  enabled: true
+  # Service account give approval permission
+  serviceAccountName: cert-manager
+  # Namespace the service account resides in
+  namespace: cert-manager
+
+# +docs:section=Monitoring
+
+serviceMonitor:
+  # Create Prometheus ServiceMonitor 
+  create: false
+  # Annotations to add to the Prometheus ServiceMonitor
+  annotations: {}
+  # Labels to add to the Prometheus ServiceMonitor
+  labels: {}


### PR DESCRIPTION
There are no docs for the helm chart, this adds auto-generated docs using helm-tool.

Preview can be seen here:
https://github.com/ThatsMrTalbot/aws-privateca-issuer/blob/feat/helm-tool-for-docs/charts/aws-pca-issuer/README.md