### PR TITLE
Update Go to 1.22.3

### DIFF
--- a/.github/workflows/on-safe-to-test-label.yml
+++ b/.github/workflows/on-safe-to-test-label.yml
@@ -79,7 +79,7 @@ jobs:
           mkdir /home/ec2-user/.cache/go-mod
           mkdir /home/ec2-user/go
           mkdir /home/ec2-user/go/bin
-          GOVERSION=go1.21.6
+          GOVERSION=go1.22.3
           wget https://go.dev/dl/$GOVERSION.linux-amd64.tar.gz
           sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf $GOVERSION.linux-amd64.tar.gz
           PATH="$PATH:/usr/local/go/bin"


### PR DESCRIPTION
- This will update our workflow for the next run to allow us to run with the new go version in our go mod