### PR TITLE
feat: Support disabling Kubernetes client side rate limiting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ OS := $(shell go env GOOS)
 ARCH := $(shell go env GOARCH)
 
 # Kind
-KIND_VERSION := 0.11.1
+KIND_VERSION := 0.19.0
 KIND := ${BIN}/kind-${KIND_VERSION}
 K8S_CLUSTER_NAME := pca-external-issuer
 
@@ -281,7 +281,8 @@ kind-export-logs:
 
 .PHONY: deploy-cert-manager
 deploy-cert-manager: ## Deploy cert-manager in the configured Kubernetes cluster in ~/.kube/config
-	kubectl apply --filename=https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml --kubeconfig=${TEST_KUBECONFIG_LOCATION}
+	helm repo add jetstack https://charts.jetstack.io --force-update
+	helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version ${CERT_MANAGER_VERSION} --set installCRDs=true --set config.apiVersion=controller.config.cert-manager.io/v1alpha1 --set config.kind=ControllerConfiguration --set config.kubernetesAPIQPS=10000 --set config.kubernetesAPIBurst=10000 --kubeconfig=${TEST_KUBECONFIG_LOCATION}
 	kubectl wait --for=condition=Available --timeout=300s apiservice v1.cert-manager.io --kubeconfig=${TEST_KUBECONFIG_LOCATION}
 
 .PHONY: install-local

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ signing. If using an older version of cert-manager (pre v1.3), you can disable
 this check by supplying the command line flag `-disable-approved-check` to the
 Issuer Deployment.
 
+### Disable Kubernetes Client-Side Rate Limiting
+
+The AWSPCA Issuer will throttle the rate of requests to the kubernetes API server to 5 queries per second by [default](https://pkg.go.dev/k8s.io/client-go/rest#pkg-constants). This is not necessary for newer versions of Kubernetes that have implemented [API Priority and Fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/). If using a newer version of Kubernetes, you can disable this client-side rate limiting by supplying the command line flag `-disable-client-side-rate-limiting` to the Issuer Deployment.
+
 ### Authentication
 
 Please note that if you are using [KIAM](https://github.com/uswitch/kiam) for authentication, this plugin has been tested on KIAM v4.0. [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) is also tested and supported.

--- a/charts/aws-pca-issuer/templates/deployment.yaml
+++ b/charts/aws-pca-issuer/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
             {{- if .Values.disableApprovedCheck }}
             - -disable-approved-check
             {{- end }}
+            {{- if .Values.disableClientSideRateLimiting }}
+            - -disable-client-side-rate-limiting
+            {{- end }}
           ports:
             - containerPort: 8080
               name: http

--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -14,6 +14,9 @@ image:
 # Disable waiting for CertificateRequests to be Approved before signing
 disableApprovedCheck: false
 
+# Disables Kubernetes client-side rate limiting (only use if API Priority & Fairness is enabled on the cluster).
+disableClientSideRateLimiting: false
+
 # Optional secrets used for pulling the container image
 #
 # For example:

--- a/e2e/kind_config/config.yaml
+++ b/e2e/kind_config/config.yaml
@@ -11,7 +11,7 @@ containerdConfigPatches:
     endpoint = ["http://kind-registry:5000"]
 nodes:
 - role: control-plane
-  image: "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
+  image: "kindest/node:v1.22.17@sha256:9af784f45a584f6b28bce2af84c494d947a05bd709151466489008f80a9ce9d5"
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var disableApprovedCheck bool
+	var disableClientSideRateLimiting bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -66,6 +67,8 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&disableApprovedCheck, "disable-approved-check", false,
 		"Disables waiting for CertificateRequests to have an approved condition before signing.")
+	flag.BoolVar(&disableClientSideRateLimiting, "disable-client-side-rate-limiting", false,
+		"Disables Kubernetes client-side rate limiting (only use if API Priority & Fairness is enabled on the cluster).")
 
 	opts := zap.Options{
 		Development: false,
@@ -75,7 +78,15 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	config := ctrl.GetConfigOrDie()
+	if disableClientSideRateLimiting {
+		// A negative QPS and Burst indicates that the client should not have a rate limiter.
+		// Ref: https://github.com/kubernetes/kubernetes/blob/v1.24.0/staging/src/k8s.io/client-go/rest/config.go#L354-L364
+		setupLog.Info("Disabling Kubernetes client rate limiter.")
+		config.QPS = -1
+		config.Burst = -1
+	}
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,


### PR DESCRIPTION
This should _theoretically_ resolve #334.

Note that I haven't had the chance to test this at all - I _believe_ it works (and I based a good bit of my work on the changes in https://github.com/cert-manager/istio-csr/pull/352 which does the same thing for `istio-csr`), but I haven't actually proven that out end-to-end by adding unit and integration tests because I don't really have a deep understanding of the test suite here.

This PR includes:
- new value in Helm values, `disableClientSideRateLimiting`
- corresponding new command line option
- Using this new option to set `config.QPS` and `config.Burst` for the Kubernetes REST client