### PR TITLE
use sha256 sum for idempotency token

### DIFF
--- a/pkg/aws/pca.go
+++ b/pkg/aws/pca.go
@@ -19,7 +19,7 @@ package aws
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/pem"
 	"fmt"
 	"strings"
@@ -91,8 +91,9 @@ func NewProvisioner(config aws.Config, arn string) (p *PCAProvisioner) {
 // idempotencyToken is limited to 64 ASCII characters, so make a fixed length hash.
 // @see: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html
 func idempotencyToken(cr *cmapi.CertificateRequest) string {
-	token := []byte(cr.ObjectMeta.Namespace + "/" + cr.ObjectMeta.Name)
-	return fmt.Sprintf("%x", md5.Sum(token))
+    token := []byte(cr.ObjectMeta.Namespace + "/" + cr.ObjectMeta.Name)
+    fullHash := fmt.Sprintf("%x", sha256.Sum256(token))
+    return fullHash[:36] // Truncate to 36 characters
 }
 
 // Sign takes a certificate request and signs it using PCA

--- a/pkg/aws/pca_test.go
+++ b/pkg/aws/pca_test.go
@@ -325,8 +325,9 @@ func TestIdempotencyToken(t *testing.T) {
 					Namespace: "fake-namespace",
 				},
 			},
-			expected: "f331cbfd0cc6569f58c12c3dbb238a4f",
+			expected: "63e69830270b95081942a3d85034fdc97bb9", // Truncated SHA-256 hash
 		},
+		
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
As of now we use a bit less secure md5 for idempotency token, I think we should prefer to use more secure sha256sum for it and this PR aims to do that, thanks!