### PR TITLE
Run tests with cert-manager 1.16.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ KIND := ${BIN}/kind-${KIND_VERSION}
 K8S_CLUSTER_NAME := pca-external-issuer
 
 # cert-manager
-CERT_MANAGER_VERSION ?= v1.14.5
+CERT_MANAGER_VERSION ?= v1.16.0
 
 # Controller tools
 CONTROLLER_GEN_VERSION := 0.15.0


### PR DESCRIPTION
I'm not sure if you prefer to run the E2E tests against an older established version of cert-manager, 
but with the release of cert-manager 1.16 yesterday, we have removed 1.14 from the supported versions page.

- This PR was originally opened to run the aws-privateca-issuer E2E tests against cert-manager v1.16.0-beta.0.
- The tests passed.
- cert-manager v1.16.0 was released.
- So I updated the PR to run the E2E tests with released version of cert-manager: v1.16.0
  * https://github.com/cert-manager/cert-manager/releases/tag/v1.16.0

@ARichman555 Consider adding the supported cert-manager version to this page:
 * https://cert-manager.io/docs/configuration/issuers/

