### PR TITLE
Update blog test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ kind-export-logs:
 .PHONY: deploy-cert-manager
 deploy-cert-manager: ## Deploy cert-manager in the configured Kubernetes cluster in ~/.kube/config
 	helm repo add jetstack https://charts.jetstack.io --force-update
-	helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version ${CERT_MANAGER_VERSION} --set installCRDs=true --set config.apiVersion=controller.config.cert-manager.io/v1alpha1 --set config.kind=ControllerConfiguration --set config.kubernetesAPIQPS=10000 --set config.kubernetesAPIBurst=10000 --kubeconfig=${TEST_KUBECONFIG_LOCATION}
+	helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version ${CERT_MANAGER_VERSION} --set crds.enabled=true --set config.apiVersion=controller.config.cert-manager.io/v1alpha1 --set config.kind=ControllerConfiguration --set config.kubernetesAPIQPS=10000 --set config.kubernetesAPIBurst=10000 --kubeconfig=${TEST_KUBECONFIG_LOCATION}
 	kubectl wait --for=condition=Available --timeout=300s apiservice v1.cert-manager.io --kubeconfig=${TEST_KUBECONFIG_LOCATION}
 
 .PHONY: install-local

--- a/e2e/kind_config/install_eks.yaml
+++ b/e2e/kind_config/install_eks.yaml
@@ -107,7 +107,7 @@ spec:
       serviceAccountName: pod-identity-webhook
       containers:
         - name: pod-identity-webhook
-          image: public.ecr.aws/perplexed/amazon-eks-pod-identity-webhook:latest
+          image: amazon/amazon-eks-pod-identity-webhook:latest
           imagePullPolicy: IfNotPresent
           command:
             - /webhook
@@ -169,7 +169,7 @@ spec:
     name: selfsigned-issuer
     kind: ClusterIssuer
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: pod-identity-webhook
@@ -179,6 +179,8 @@ metadata:
 webhooks:
   - name: pod-identity-webhook.amazonaws.com
     failurePolicy: Ignore
+    sideEffects: None
+    admissionReviewVersions: ['v1', 'v1beta']
     clientConfig:
       service:
         name: pod-identity-webhook


### PR DESCRIPTION
This removes some deprecated resources we were using for the eks web hook. This also makes it so the cleanup step for the blog-test will always run, even if the test fails.