### PR TITLE
Add certificate arn to log statement

### DIFF
--- a/pkg/aws/pca.go
+++ b/pkg/aws/pca.go
@@ -162,7 +162,7 @@ func (p *PCAProvisioner) Get(ctx context.Context, cr *cmapi.CertificateRequest, 
 	}
 	certPem = append(certPem, chainIntCAs...)
 
-	log.Info("Created certificate with arn: ")
+	log.Info("Created certificate with arn: " + certArn)
 
 	return certPem, rootCA, nil
 }


### PR DESCRIPTION
This fixes a small bug in the log statement when a certificate is finally issued.