### PR TITLE
feat(helm): Allow priorityClassName configuration

### DIFF
--- a/charts/aws-pca-issuer/README.md
+++ b/charts/aws-pca-issuer/README.md
@@ -469,6 +469,29 @@ topologySpreadConstraints:
 </tr>
 <tr>
 
+<td>priorityClassName</td>
+<td>
+
+Priority class name for the issuer pods. If specified, this will set the priority class on pods, which can influence scheduling decisions.
+
+For example:
+
+```yaml
+priorityClassName: high-priority
+```
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+""
+```
+
+</td>
+</tr>
+<tr>
+
 <td>env</td>
 <td>
 

--- a/charts/aws-pca-issuer/templates/deployment.yaml
+++ b/charts/aws-pca-issuer/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "aws-privateca-issuer.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -113,6 +113,13 @@ affinity: {}
 #         app.kubernetes.io/name: aws-privateca-issuer
 topologySpreadConstraints: []
 
+# Priority class name for the issuer pods
+# If specified, this will set the priority class on pods, which can influence scheduling decisions
+#
+# For example:
+#   priorityClassName: high-priority
+priorityClassName: ""
+
 # Additional environment variables to set in the Pod
 # +docs:type=object
 env:


### PR DESCRIPTION
This change allows users to configure the PriorityClassName on pods that are spun up by the aws-privateca-issuer in order to influence scheduling decisions and potentially prevent eviction.

This change has been tested and below screenshot confirms that the priorityClassName has been set on the pod.
<img width="547" alt="PriorityClassNamePod" src="https://github.com/user-attachments/assets/808cca8e-5d6d-4a09-a8ff-ee9b0a1fd1aa" />
