### PR TITLE
Make the arm and x86 end-to-end tests run concurrently

### DIFF
--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -19,7 +19,6 @@ jobs:
     uses: './.github/workflows/on-safe-to-test-label.yml'
     with:
       architecture: 'x86_64'
-    needs: run-for-arm
 
   remove-safe-to-test:
     name: Remove Safe to Test Label

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ REGISTRY_NAME := "kind-registry"
 REGISTRY_PORT := 5000
 LOCAL_IMAGE := "localhost:${REGISTRY_PORT}/aws-privateca-issuer"
 NAMESPACE := aws-privateca-issuer
-SERVICE_ACCOUNT := ${NAMESPACE}-sa
+SERVICE_ACCOUNT := ${NAMESPACE}-sa-${ARCH}
 TEST_KUBECONFIG_LOCATION := /tmp/pca_kubeconfig
 
 create-local-registry:


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

This will make the x86 and arm end-to-end tests run concurrently instead of sequentially.

### Description of changes

This change removed the dependency between the two test runs. It also made it so the architecture was added to the service account to prevent issues with having multiple webhooks attached to a single service account at one time.

### Describe any new or updated permissions being added

There are no new permissions being updated or added.

### Description of how you validated changes

Ran e2etest locally
