### PR TITLE
Sync CRDs between config/crd/bases and charts/aws-pca-issuer/crds

### DIFF
--- a/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaclusterissuers.yaml
+++ b/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaclusterissuers.yaml
@@ -47,6 +47,25 @@ spec:
                 description: Needs to be specified if you want to authorize with AWS
                   using an access and secret key
                 properties:
+                  accessKeyIDSelector:
+                    description: Specifies the secret key where the AWS Access Key
+                      ID exists
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
                   name:
                     description: Name is unique within a namespace to reference a
                       secret resource.
@@ -55,6 +74,25 @@ spec:
                     description: Namespace defines the space within which the secret
                       name must be unique.
                     type: string
+                  secretAccessKeySelector:
+                    description: Specifies the secret key where the AWS Secret Access
+                      Key exists
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
                 type: object
             type: object
           status:

--- a/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaissuers.yaml
+++ b/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaissuers.yaml
@@ -46,6 +46,25 @@ spec:
                 description: Needs to be specified if you want to authorize with AWS
                   using an access and secret key
                 properties:
+                  accessKeyIDSelector:
+                    description: Specifies the secret key where the AWS Access Key
+                      ID exists
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
                   name:
                     description: Name is unique within a namespace to reference a
                       secret resource.
@@ -54,6 +73,25 @@ spec:
                     description: Namespace defines the space within which the secret
                       name must be unique.
                     type: string
+                  secretAccessKeySelector:
+                    description: Specifies the secret key where the AWS Secret Access
+                      Key exists
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
                 type: object
             type: object
           status:


### PR DESCRIPTION


### Issue #381

Closes #381

### Reason for this change

We have a workflow for this that triggers upon pull requests, but this was unfortunately added after the two had already drifted, and no further commits have updated the CRDs since. This change fixes the drift between the two directories.

### Description of changes

Change was made via the following, which was more or less taken directly from .github/workflows/sync.yml:
```
CONFIG_DIR=config/crd/bases
CHARTS_DIR=charts/aws-pca-issuer/crds
cp ${CONFIG_DIR}/*.yaml ${CHARTS_DIR}
```


### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

N/A