### PR TITLE
Update certificate to Pending instead of Failed when issuer is not ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ testbin/*
 .idea
 *.swp
 *.swo
+*.swn
 *~
 
 #ignore files created during integ tests

--- a/e2e/k8_helpers.go
+++ b/e2e/k8_helpers.go
@@ -56,6 +56,39 @@ func waitForClusterIssuerReady(ctx context.Context, client *clientV1beta1.Client
 		})
 }
 
+func waitForCertificateRequestPending(ctx context.Context, client *cmclientv1.CertmanagerV1Client, name string, namespace string) error {
+	return wait.PollImmediate(250*time.Millisecond, 2*time.Minute,
+		func() (bool, error) {
+
+			cr, err := client.CertificateRequests(namespace).Get(ctx, name, metav1.GetOptions{})
+
+			if err != nil {
+				return false, fmt.Errorf("error getting CertificateRequest %q: %v", name, err)
+			}
+
+			for _, condition := range cr.Status.Conditions {
+				if condition.Reason == v1.CertificateRequestReasonPending && condition.Status == cmv1.ConditionFalse {
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+}
+
+func waitForCertificateRequestToBeCreated(ctx context.Context, client *cmclientv1.CertmanagerV1Client, name string, namespace string) error {
+	return wait.PollImmediate(250*time.Millisecond, 2*time.Minute,
+		func() (bool, error) {
+
+			_, err := client.CertificateRequests(namespace).Get(ctx, name, metav1.GetOptions{})
+
+			if err != nil {
+				return false, nil
+			}
+
+			return true, nil
+		})
+}
+
 func waitForCertificateReady(ctx context.Context, client *cmclientv1.CertmanagerV1Client, name string, namespace string) error {
 	return wait.PollImmediate(250*time.Millisecond, 2*time.Minute,
 		func() (bool, error) {

--- a/pkg/aws/pca.go
+++ b/pkg/aws/pca.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -28,16 +29,27 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/middleware"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/acmpca"
 	acmpcatypes "github.com/aws/aws-sdk-go-v2/service/acmpca/types"
 	injections "github.com/cert-manager/aws-privateca-issuer/pkg/api/injections"
+	api "github.com/cert-manager/aws-privateca-issuer/pkg/api/v1beta1"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/go-logr/logr"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const DEFAULT_DURATION = 30 * 24 * 3600
+
+var (
+	ErrNoSecretAccessKey = errors.New("no AWS Secret Access Key Found")
+	ErrNoAccessKeyID     = errors.New("no AWS Access Key ID Found")
+)
 
 var collection = new(sync.Map)
 
@@ -62,38 +74,103 @@ type PCAProvisioner struct {
 	clock            func() time.Time
 }
 
-// GetProvisioner gets a provisioner that has previously been stored
-func GetProvisioner(name types.NamespacedName) (GenericProvisioner, bool) {
-	value, exists := collection.Load(name)
-	if !exists {
-		return nil, exists
+func GetConfig(ctx context.Context, client client.Client, spec *api.AWSPCAIssuerSpec) (aws.Config, error) {
+	cfg, err := LoadConfig(ctx, client, spec)
+
+	if err != nil {
+		return aws.Config{}, err
 	}
 
-	p, exists := value.(GenericProvisioner)
-	return p, exists
+	cfg.Retryer = func() aws.Retryer {
+		return retry.AddWithErrorCodes(retry.NewStandard(), (*acmpcatypes.RequestInProgressException)(nil).ErrorCode())
+	}
+
+	return cfg, nil
 }
 
-// StoreProvisioner stores a provisioner in the cache
-func StoreProvisioner(name types.NamespacedName, provisioner GenericProvisioner) {
-	collection.Store(name, provisioner)
+func LoadConfig(ctx context.Context, client client.Client, spec *api.AWSPCAIssuerSpec) (aws.Config, error) {
+	if spec.SecretRef.Name != "" {
+		secretNamespaceName := types.NamespacedName{
+			Namespace: spec.SecretRef.Namespace,
+			Name:      spec.SecretRef.Name,
+		}
+
+		secret := new(core.Secret)
+		if err := client.Get(ctx, secretNamespaceName, secret); err != nil {
+			return aws.Config{}, fmt.Errorf("failed to retrieve secret: %v", err)
+		}
+
+		key := "AWS_ACCESS_KEY_ID"
+		if spec.SecretRef.AccessKeyIDSelector.Key != "" {
+			key = spec.SecretRef.AccessKeyIDSelector.Key
+		}
+		accessKey, ok := secret.Data[key]
+		if !ok {
+			return aws.Config{}, ErrNoAccessKeyID
+		}
+
+		key = "AWS_SECRET_ACCESS_KEY"
+		if spec.SecretRef.SecretAccessKeySelector.Key != "" {
+			key = spec.SecretRef.SecretAccessKeySelector.Key
+		}
+		secretKey, ok := secret.Data[key]
+		if !ok {
+			return aws.Config{}, ErrNoSecretAccessKey
+		}
+
+		if spec.Region != "" {
+			return config.LoadDefaultConfig(ctx,
+				config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(string(accessKey), string(secretKey), "")),
+				config.WithRegion(spec.Region),
+			)
+		}
+
+		return config.LoadDefaultConfig(ctx,
+			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(string(accessKey), string(secretKey), "")),
+		)
+	} else if spec.Region != "" {
+		return config.LoadDefaultConfig(ctx,
+			config.WithRegion(spec.Region),
+		)
+	}
+
+	return config.LoadDefaultConfig(ctx)
 }
 
-// NewProvisioner returns a new PCAProvisioner
-func NewProvisioner(config aws.Config, arn string) (p *PCAProvisioner) {
-	return &PCAProvisioner{
+func ClearProvisioners() {
+	collection.Clear()
+}
+
+// GetProvisioner gets a provisioner that has previously been stored or creates a new one
+func GetProvisioner(ctx context.Context, client client.Client, name types.NamespacedName, spec *api.AWSPCAIssuerSpec) (GenericProvisioner, error) {
+	value, _ := collection.Load(name)
+	p, isProvisioner := value.(GenericProvisioner)
+	if isProvisioner {
+		return p, nil
+	}
+
+	config, err := GetConfig(ctx, client, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	provisioner := &PCAProvisioner{
 		pcaClient: acmpca.NewFromConfig(config, acmpca.WithAPIOptions(
 			middleware.AddUserAgentKeyValue("aws-privateca-issuer", injections.PlugInVersion),
 		)),
-		arn: arn,
+		arn: spec.Arn,
 	}
+	collection.Store(name, provisioner)
+
+	return provisioner, nil
 }
 
 // idempotencyToken is limited to 64 ASCII characters, so make a fixed length hash.
 // @see: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html
 func idempotencyToken(cr *cmapi.CertificateRequest) string {
-    token := []byte(cr.ObjectMeta.Namespace + "/" + cr.ObjectMeta.Name)
-    fullHash := fmt.Sprintf("%x", sha256.Sum256(token))
-    return fullHash[:36] // Truncate to 36 characters
+	token := []byte(cr.ObjectMeta.Namespace + "/" + cr.ObjectMeta.Name)
+	fullHash := fmt.Sprintf("%x", sha256.Sum256(token))
+	return fullHash[:36] // Truncate to 36 characters
 }
 
 // Sign takes a certificate request and signs it using PCA

--- a/pkg/controllers/certificaterequest_controller.go
+++ b/pkg/controllers/certificaterequest_controller.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	acmpcatypes "github.com/aws/aws-sdk-go-v2/service/acmpca/types"
-	"github.com/cert-manager/aws-privateca-issuer/pkg/aws"
+	awspca "github.com/cert-manager/aws-privateca-issuer/pkg/aws"
 	"github.com/cert-manager/aws-privateca-issuer/pkg/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -52,6 +52,11 @@ type CertificateRequestReconciler struct {
 	Clock                  clock.Clock
 	CheckApprovedCondition bool
 }
+
+// We put this in a variable to easily mock it
+var (
+	GetProvisioner = awspca.GetProvisioner
+)
 
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificaterequests,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificaterequests/status,verbs=get;update;patch
@@ -145,19 +150,18 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 	iss, err := util.GetIssuer(ctx, r.Client, issuerName)
 	if err != nil {
 		log.Error(err, "failed to retrieve Issuer resource")
-		_ = r.setStatus(ctx, cr, cmmeta.ConditionFalse, cmapi.CertificateRequestReasonFailed, "issuer could not be found")
+		_ = r.setStatus(ctx, cr, cmmeta.ConditionFalse, cmapi.CertificateRequestReasonPending, "issuer could not be found")
 		return ctrl.Result{}, err
 	}
 
 	if !isReady(iss) {
 		err := fmt.Errorf("issuer %s is not ready", iss.GetName())
-		_ = r.setStatus(ctx, cr, cmmeta.ConditionFalse, cmapi.CertificateRequestReasonFailed, "issuer is not ready")
+		_ = r.setStatus(ctx, cr, cmmeta.ConditionFalse, cmapi.CertificateRequestReasonPending, "issuer is not ready")
 		return ctrl.Result{}, err
 	}
 
-	provisioner, ok := aws.GetProvisioner(issuerName)
-	if !ok {
-		err := fmt.Errorf("provisioner for %s not found", issuerName)
+	provisioner, err := GetProvisioner(ctx, r.Client, issuerName, iss.GetSpec())
+	if err != nil {
 		log.Error(err, "failed to retrieve provisioner")
 		_ = r.setStatus(ctx, cr, cmmeta.ConditionFalse, cmapi.CertificateRequestReasonFailed, "failed to retrieve provisioner")
 		return ctrl.Result{}, err

--- a/pkg/controllers/genericissuer_controller_test.go
+++ b/pkg/controllers/genericissuer_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	awspca "github.com/cert-manager/aws-privateca-issuer/pkg/aws"
 	logrtesting "github.com/go-logr/logr/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -297,7 +298,7 @@ func TestIssuerReconcile(t *testing.T) {
 				},
 			},
 			expectedReadyConditionStatus: metav1.ConditionFalse,
-			expectedError:                errNoAccessKeyID,
+			expectedError:                awspca.ErrNoAccessKeyID,
 			expectedResult:               ctrl.Result{},
 		},
 		"failure-issuer-no-access-key-specified-with-selector": {
@@ -342,7 +343,7 @@ func TestIssuerReconcile(t *testing.T) {
 				},
 			},
 			expectedReadyConditionStatus: metav1.ConditionFalse,
-			expectedError:                errNoAccessKeyID,
+			expectedError:                awspca.ErrNoAccessKeyID,
 			expectedResult:               ctrl.Result{},
 		},
 		"failure-issuer-no-secret-access-key-specified": {
@@ -383,7 +384,7 @@ func TestIssuerReconcile(t *testing.T) {
 				},
 			},
 			expectedReadyConditionStatus: metav1.ConditionFalse,
-			expectedError:                errNoSecretAccessKey,
+			expectedError:                awspca.ErrNoSecretAccessKey,
 			expectedResult:               ctrl.Result{},
 		},
 		"failure-issuer-no-secret-access-key-specified-with-selector": {
@@ -428,7 +429,7 @@ func TestIssuerReconcile(t *testing.T) {
 				},
 			},
 			expectedReadyConditionStatus: metav1.ConditionFalse,
-			expectedError:                errNoSecretAccessKey,
+			expectedError:                awspca.ErrNoSecretAccessKey,
 			expectedResult:               ctrl.Result{},
 		},
 	}


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

This will allow cert-manager to recover itself after the pod has downtime. As of now, the certificate requests will enter a terminal failed state which means cert-manager will never retry. By putting these in Pending, we can retry according to cert-manager's retry strategy. 

### Description of changes
* Updates the certificate status to Pending instead of Failed if the issuer is not found or is not ready
* Moves the provisioner to always be made at issuance time (prevents branching logic)
* Re-creates the provisioner if it does not already exist at issuance time
* Adds unit tests for everything

### Describe any new or updated permissions being added

There are no new permissions being updated or added.

### Description of how you validated changes

Added unit tests and tested locally with e2e tests. Also manually tested edge cases presented by customer
