### PR TITLE
Improve end-to-end test time

### DIFF
--- a/.github/workflows/on-safe-to-test-label.yml
+++ b/.github/workflows/on-safe-to-test-label.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   AWS_CLI_ARCHITECTURE: ${{ inputs.architecture == 'arm64' && 'aarch64' || 'x86_64' }}
-  EC2_INSTANCE_TYPE: ${{ inputs.architecture == 'arm64' && 't4g.medium' || 't3.medium' }}
+  EC2_INSTANCE_TYPE: ${{ inputs.architecture == 'arm64' && 'c7gn.xlarge' || 'c7a.xlarge' }}
   GO_ARCHITECTURE: ${{ inputs.architecture == 'arm64' && 'arm64' || 'amd64' }}
   KUBECTL_ARCHITECTURE: $GO_ARCHITECTURE
 

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -19,7 +19,6 @@ jobs:
     uses: './.github/workflows/on-safe-to-test-label.yml'
     with:
       architecture: 'x86_64'
-    needs: run-for-arm
 
   remove-safe-to-test:
     name: Remove Safe to Test Label

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ ENV GOPROXY=direct
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
 
 # Copy the go source
 COPY main.go main.go
@@ -21,15 +18,21 @@ ENV CGO_ENABLED=0
 ENV GOOS=${TARGETOS:-linux}
 ENV GOARCH=${TARGETARCH:-amd64}
 ENV GO111MODULE=on
+ARG go_cache
+ARG go_mod_cache
+
+RUN go env -w GOCACHE=${go_cache}
+RUN go env -w GOMODCACHE=${go_mod_cache}
 
 # Do an initial compilation before setting the version so that there is less to
 # re-compile when the version changes
-RUN go build -mod=readonly ./...
+RUN --mount=type=cache,target=${go_cache} --mount=type=cache,target=${go_mod_cache} go build ./...
 
 ARG pkg_version
 
 # Build
-RUN VERSION=$pkg_version && \
+RUN --mount=type=cache,target=${go_cache} --mount=type=cache,target=${go_mod_cache} \
+    VERSION=$pkg_version && \
     go build \
     -ldflags="-X=github.com/cert-manager/acm-pca-issuer/internal/version.Version=${VERSION} \
     -X github.com/cert-manager/aws-privateca-issuer/pkg/api/injections.PlugInVersion=${VERSION}" \

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+GOCACHE ?= $(shell go env GOCACHE)
+GOMODCACHE ?= $(shell go env GOMODCACHE)
+
 # BIN is the directory where tools will be installed
 export BIN ?= ${CURDIR}/bin
 
@@ -142,6 +145,8 @@ generate: controller-gen
 # Build the docker image
 docker-build: test
 	docker build \
+		--build-arg go_cache=${GOCACHE} \
+		--build-arg go_mod_cache=${GOMODCACHE} \
 		--build-arg pkg_version=${VERSION} \
 		--tag ${IMG} \
 		--file Dockerfile \
@@ -209,7 +214,7 @@ REGISTRY_NAME := "kind-registry"
 REGISTRY_PORT := 5000
 LOCAL_IMAGE := "localhost:${REGISTRY_PORT}/aws-privateca-issuer"
 NAMESPACE := aws-privateca-issuer
-SERVICE_ACCOUNT := ${NAMESPACE}-sa
+SERVICE_ACCOUNT := ${NAMESPACE}-${ARCH}-sa
 TEST_KUBECONFIG_LOCATION := /tmp/pca_kubeconfig
 
 create-local-registry:


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The purpose of this is to improve the time it takes to run the test suite

### Description of changes
* Removes `go mod download` because it's archaic, opts to just use `go build` instead
* Adds two build args to the docker build that specify where to find the go-caches (this helps a lot with local build times)
* Modifies the Dockerfile to manually set the Go env variables
* Modifies the Dockerfile to use the build arguments and mount the directories as caches
* Updates the EC2 instance types to be faster
* Updates the service account name to include the architecture
* Updates the ARM and x86 tests to run in parallel

### Describe any new or updated permissions being added

There are no new permissions being updated or added.

### Description of how you validated changes

Tested with local build and GitHub workflows on my own fork
