### PR TITLE
Add defaults for Docker build-args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ ENV CGO_ENABLED=0
 ENV GOOS=${TARGETOS:-linux}
 ENV GOARCH=${TARGETARCH:-amd64}
 ENV GO111MODULE=on
-ARG go_cache
-ARG go_mod_cache
+ARG go_cache=/pkg/go-cache
+ARG go_mod_cache=/pkg/go-mod
 
 RUN go env -w GOCACHE=${go_cache}
 RUN go env -w GOMODCACHE=${go_mod_cache}


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

This change prevents Docker build failures if the Go environment variables are not set correctly.

### Description of changes

* This adds default values for the Docker build-args in the Dockerfile.

### Describe any new or updated permissions being added

There are no new permissions being updated or added.

### Description of how you validated changes

Tested this on my fork
