### PR TITLE
Set the user-agent based on the destination repo of the built image

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -8,6 +8,8 @@ on:
 env:
   PUBLIC_REGISTRY: public.ecr.aws/k1n1h4h4
   PRIVATE_REGISTRY: 105154636954.dkr.ecr.us-east-1.amazonaws.com
+  ECR_USER_AGENT: aws-privateca-issuer
+  EKS_USER_AGENT: aws-privateca-connector-for-kubernetes-eks-addon
 
 jobs:
   build:
@@ -44,6 +46,7 @@ jobs:
         with:
           build-args: |
             pkg_version=${{ steps.tag.outputs.tag }}
+            user_agent=${{ env.ECR_USER_AGENT }}
           context: .
           platforms: linux/amd64,linux/arm64
           tags: |
@@ -65,6 +68,7 @@ jobs:
         with:
           build-args: |
             pkg_version=${{ steps.tag.outputs.tag }}
+            user_agent=${{ env.EKS_USER_AGENT }}
           context: .
           platforms: linux/arm64
           provenance: false
@@ -76,6 +80,7 @@ jobs:
         with:
           build-args: |
             pkg_version=${{ steps.tag.outputs.tag }}
+            user_agent=${{ env.EKS_USER_AGENT }}
           context: .
           platforms: linux/amd64
           provenance: false
@@ -87,6 +92,7 @@ jobs:
         with:
           build-args: |
             pkg_version=${{ steps.tag.outputs.tag }}
+            user_agent=${{ env.EKS_USER_AGENT }}
           context: .
           platforms: linux/amd64,linux/arm64
           provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,16 @@ RUN --mount=type=cache,target=${go_cache} --mount=type=cache,target=${go_mod_cac
 
 ARG pkg_version
 
+ARG user_agent="aws-privateca-issuer"
+
 # Build
 RUN --mount=type=cache,target=${go_cache} --mount=type=cache,target=${go_mod_cache} \
     VERSION=$pkg_version && \
+    USER_AGENT=$user_agent && \
     go build \
     -ldflags="-X=github.com/cert-manager/acm-pca-issuer/internal/version.Version=${VERSION} \
-    -X github.com/cert-manager/aws-privateca-issuer/pkg/api/injections.PlugInVersion=${VERSION}" \
+    -X github.com/cert-manager/aws-privateca-issuer/pkg/api/injections.PlugInVersion=${VERSION} \
+    -X github.com/cert-manager/aws-privateca-issuer/pkg/api/injections.UserAgent=${USER_AGENT}" \
     -mod=readonly \
     -o manager main.go
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,8 @@ blog-test:
 # Build manager binary
 manager: generate fmt vet lint
 	go build \
-	-ldflags="-X github.com/cert-manager/aws-privateca-issuer/pkg/api/injections.PlugInVersion=${VERSION}" \
+	-ldflags="-X github.com/cert-manager/aws-privateca-issuer/pkg/api/injections.PlugInVersion=${VERSION} \
+	-X github.com/cert-manager/aws-privateca-issuer/pkg/api/injections.UserAgent=aws-privateca-issuer" \
 	-o bin/manager main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
@@ -148,6 +149,7 @@ docker-build: test
 		--build-arg go_cache=${GOCACHE} \
 		--build-arg go_mod_cache=${GOMODCACHE} \
 		--build-arg pkg_version=${VERSION} \
+		--build-arg user_agent=aws-privateca-issuer \
 		--tag ${IMG} \
 		--file Dockerfile \
 		--platform=linux/amd64,linux/arm64 \

--- a/pkg/api/injections/injection_targets.go
+++ b/pkg/api/injections/injection_targets.go
@@ -4,3 +4,7 @@ var (
 	// PlugInVersion is the git version of the cert-manager plugin
 	PlugInVersion string
 )
+
+var (
+	UserAgent string
+)

--- a/pkg/aws/pca.go
+++ b/pkg/aws/pca.go
@@ -156,7 +156,7 @@ func GetProvisioner(ctx context.Context, client client.Client, name types.Namesp
 
 	provisioner := &PCAProvisioner{
 		pcaClient: acmpca.NewFromConfig(config, acmpca.WithAPIOptions(
-			middleware.AddUserAgentKeyValue("aws-privateca-issuer", injections.PlugInVersion),
+			middleware.AddUserAgentKeyValue(injections.UserAgent, injections.PlugInVersion),
 		)),
 		arn: spec.Arn,
 	}


### PR DESCRIPTION
### Issue # (if applicable)
N/A

### Reason for this change
Allows for configuring the user-agent on IssueCertificate requests

### Description of changes
Configures user-agent based on the destination repo of the build image. The existing public ECR repository will continue to have a UserAgent containing `aws-privateca-issuer`, and the private ECR repository will now have a UserAgent containing `aws-privateca-connector-for-kubernetes`

<!--
What code changes did you make?
Have you made any important design decisions?
What use cases does this change enable?
-->

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

On a different branch of my fork that has the same changes but different ECR repositories, I made a new release to trigger the `on-release` Github Action. See changes here: https://github.com/hanleyyin/aws-privateca-issuer/commit/6e01f4251b951568bd84ecb89be11ff9e2c2d706

I installed the add on from my `PUBLIC_REGISTRY` and validated that the `IssueCertificate` call in Cloudtrail successfully included "aws-privateca-issuer" in the UserAgent field
```bash
[ec2-user@ip-10-0-0-114 aws-privateca-issuer]$ helm install aws-privateca-issuer awspca/aws-privateca-issuer --set image.repository=public.ecr.aws/o0l9c1h8/hanleyyin-aws-privateca-issuer --set image.tag=v1.9.12
NAME: aws-privateca-issuer
LAST DEPLOYED: Wed Apr 23 21:07:43 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
[ec2-user@ip-10-0-0-114 aws-privateca-issuer]$ kubectl apply -f cluster-issuer.yaml
awspcaclusterissuer.awspca.cert-manager.io/pca-cluster-issuer-rsa created
[ec2-user@ip-10-0-0-114 aws-privateca-issuer]$ kubectl get AWSPCAClusterIssuers -o json | jq .items[].status
{
  "conditions": [
    {
      "lastTransitionTime": "2025-04-23T21:08:03Z",
      "message": "Issuer verified",
      "reason": "Verified",
      "status": "True",
      "type": "Ready"
    }
  ]
}
[ec2-user@ip-10-0-0-114 aws-privateca-issuer]$ kubectl apply -f certificate.yaml
certificate.cert-manager.io/rsa-cert-2048 created
[ec2-user@ip-10-0-0-114 aws-privateca-issuer]$ kubectl get certificates -o json | jq .items[].status
{
  "conditions": [
    {
      "lastTransitionTime": "2025-04-23T21:08:14Z",
      "message": "Certificate is up to date and has not expired",
      "observedGeneration": 1,
      "reason": "Ready",
      "status": "True",
      "type": "Ready"
    }
  ],
  "notAfter": "2025-07-22T21:08:10Z",
  "notBefore": "2025-04-23T20:08:14Z",
  "renewalTime": "2025-07-07T21:08:10Z",
  "revision": 1
}
```

As expected, the Cloudtrail Event for the cert shows the right UserAgent:
```
    "eventTime": "2025-04-23T21:08:14Z",
    "eventSource": "acm-pca.amazonaws.com",
    "eventName": "IssueCertificate",
    "awsRegion": "us-east-1",
    "sourceIPAddress": <redact>,
    "userAgent": "aws-sdk-go-v2/1.36.3 ua/2.1 os/linux lang/go#1.24.2 md/GOOS#linux md/GOARCH#amd64 api/acmpca#1.40.2 aws-privateca-issuer/v1.9.12 m/0",
```

I then uninstalled the addon, deleted all resources, and reinstalled the addon from my `PRIVATE_REGISTRY` and validated that the `IssueCertificate` call in Cloudtrail successfully included "aws-privateca-connector-for-kubernetes" in the UserAgent field

```bash
[ec2-user@ip-10-0-0-114 aws-privateca-issuer]$ helm uninstall aws-privateca-issuer
release "aws-privateca-issuer" uninstalled
[ec2-user@ip-10-0-0-114 aws-privateca-issuer]$ kubectl delete AWSPCAClusterIssuer --all
kubectl delete certificate --all
kubectl delete secrets/rsa-cert-2048
awspcaclusterissuer.awspca.cert-manager.io "pca-cluster-issuer-rsa" deleted
certificate.cert-manager.io "rsa-cert-2048" deleted
secret "rsa-cert-2048" deleted
[ec2-user@ip-10-0-0-114 aws-privateca-issuer]$  helm install aws-privateca-issuer awspca/aws-privateca-issuer --set image.repository=992382396819.dkr.ecr.us-east-1.amazonaws.com/eks/aws-privateca-issuer --set image.tag=v1.9.12 --set imagePullSecrets[0].name=ecr-secret
NAME: aws-privateca-issuer
LAST DEPLOYED: Wed Apr 23 21:09:50 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
[ec2-user@ip-10-0-0-114 aws-privateca-issuer]$ kubectl apply -f cluster-issuer.yaml
awspcaclusterissuer.awspca.cert-manager.io/pca-cluster-issuer-rsa created
[ec2-user@ip-10-0-0-114 aws-privateca-issuer]$ kubectl get AWSPCAClusterIssuers -o json | jq .items[].status
{
  "conditions": [
    {
      "lastTransitionTime": "2025-04-23T21:10:13Z",
      "message": "Issuer verified",
      "reason": "Verified",
      "status": "True",
      "type": "Ready"
    }
  ]
}
[ec2-user@ip-10-0-0-114 aws-privateca-issuer]$ kubectl apply -f certificate.yaml
certificate.cert-manager.io/rsa-cert-2048 created
[ec2-user@ip-10-0-0-114 aws-privateca-issuer]$ kubectl get certificates -o json | jq .items[].status
{
  "conditions": [
    {
      "lastTransitionTime": "2025-04-23T21:10:21Z",
      "message": "Issuing certificate as Secret does not exist",
      "observedGeneration": 1,
      "reason": "DoesNotExist",
      "status": "True",
      "type": "Issuing"
    },
    {
      "lastTransitionTime": "2025-04-23T21:10:21Z",
      "message": "Issuing certificate as Secret does not exist",
      "observedGeneration": 1,
      "reason": "DoesNotExist",
      "status": "False",
      "type": "Ready"
    }
  ],
  "nextPrivateKeySecretName": "rsa-cert-2048-6dz2w"
}
```

and the correct UserAgent shows up for this as well in CloudTrail:
```
    "eventTime": "2025-04-23T21:10:25Z",
    "eventSource": "acm-pca.amazonaws.com",
    "eventName": "IssueCertificate",
    "awsRegion": "us-east-1",
    "sourceIPAddress": <redacted>,
    "userAgent": "aws-sdk-go-v2/1.36.3 ua/2.1 os/linux lang/go#1.24.2 md/GOOS#linux md/GOARCH#amd64 api/acmpca#1.40.2 aws-privateca-connector-for-kubernetes/v1.9.12 m/0",
```