### PR TITLE
Add node affinity

### DIFF
--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -99,6 +99,19 @@ tolerations: []
 #            - master
 #+docs:property
 affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/os
+          operator: In
+          values:
+          - linux
+        - key: kubernetes.io/arch
+          operator: In
+          values:
+          - amd64
+          - arm64
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
     - podAffinityTerm:


### PR DESCRIPTION
- Node affinity will tell the kubernetes scheduler which types of nodes this installation "prefers" to be installed on. In this case, all we care about is that the nodes are Linux and either arm or x86. This will prevent the scheduler from attempting to install the controller on a Windows node.

### Issue # (if applicable)
### Reason for this change

Previously users with Windows nodes would have a percentage chance of attempting to install this plugin on a Windows node, causing failures because we do not support Windows nodes

### Description of changes

Adds affinity to linux arm/x86

### Describe any new or updated permissions being added

### Description of how you validated changes

Spun up cluster with new values file and validated the deployment configuration

```
spec:
  progressDeadlineSeconds: 600
  replicas: 2
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/instance: issuer
      app.kubernetes.io/name: aws-privateca-issuer
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/instance: issuer
        app.kubernetes.io/name: aws-privateca-issuer
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: kubernetes.io/os
                operator: In
                values:
                - linux
              - key: kubernetes.io/arch
                operator: In
                values:
                - amd64
                - arm64
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchExpressions:
                - key: app.kubernetes.io/name
                  operator: In
                  values:
                  - aws-privateca-issuer
              topologyKey: kubernetes.io/hostname
            weight: 100

...
```

