### PR TITLE
Refresh the cached client when the issuer is updated

### DIFF
--- a/pkg/aws/pca.go
+++ b/pkg/aws/pca.go
@@ -141,6 +141,14 @@ func ClearProvisioners() {
 	collection.Clear()
 }
 
+// DeleteProvisioner will remove a provisioner if it already exists
+func DeleteProvisioner(ctx context.Context, client client.Client, name types.NamespacedName) {
+	_, exists := collection.Load(name)
+	if exists {
+		collection.Delete(name)
+	}
+}
+
 // GetProvisioner gets a provisioner that has previously been stored or creates a new one
 func GetProvisioner(ctx context.Context, client client.Client, name types.NamespacedName, spec *api.AWSPCAIssuerSpec) (GenericProvisioner, error) {
 	value, _ := collection.Load(name)

--- a/pkg/aws/pca_test.go
+++ b/pkg/aws/pca_test.go
@@ -246,6 +246,11 @@ func TestProvisonerOperation(t *testing.T) {
 	output, err := GetProvisioner(context.TODO(), fakeClient, types.NamespacedName{Namespace: "ns1", Name: "issuer1"}, issSpec)
 	assert.Equal(t, output, provisioner)
 	assert.Equal(t, err, nil)
+
+	DeleteProvisioner(context.TODO(), fakeClient, types.NamespacedName{Namespace: "ns1", Name: "issuer1"})
+	output, err = GetProvisioner(context.TODO(), fakeClient, types.NamespacedName{Namespace: "ns1", Name: "issuer1"}, issSpec)
+	assert.NotEqual(t, output, provisioner)
+	assert.Equal(t, err, nil)
 }
 
 func TestPCATemplateArn(t *testing.T) {

--- a/pkg/controllers/genericissuer_controller.go
+++ b/pkg/controllers/genericissuer_controller.go
@@ -72,6 +72,7 @@ func (r *GenericIssuerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
+	awspca.DeleteProvisioner(ctx, r.Client, req.NamespacedName)
 	cfg, err := awspca.GetConfig(ctx, r.Client, spec)
 	if err != nil {
 		log.Error(err, "Error loading config")


### PR DESCRIPTION
Signed-off-by: Alex Richman <wrichman@amazon.com>

### Issue #403

Closes #403.

### Reason for this change

Without this, you cannot update the issuer without creating a whole new one.

### Description of changes

Updated controller to delete the cached client whenever the issuer is updated.

### Describe any new or updated permissions being added

No new permissions are required

### Description of how you validated changes

Added unit tests. Ran e2e tests locally. Also manually tested use case where I updated the region and saw certificate issuance succeed
