### PR TITLE
Revert "Update chart version to v1.6.0"

### DIFF
--- a/charts/aws-pca-issuer/Chart.yaml
+++ b/charts/aws-pca-issuer/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: aws-privateca-issuer
 description: An addon for cert-manager to sign certificates using AWS PCA
 type: application
-version: v1.6.0
-appVersion: v1.6.0
+version: v1.5.0
+appVersion: v1.5.0


### PR DESCRIPTION
This reverts commit c69a6c53620e2e477814472b6558ca30bf215b6a.

Signed-off-by: Alex Richman <wrichman@amazon.com>

### Issue # (if applicable)

N/A

### Reason for this change

We have another PR we need to merge, but the helm chart tests fail since it's looking for the wrong image

### Description of changes

This is a straight revert which reverts the chart version back to v1.5.0

### Describe any new or updated permissions being added

No

### Description of how you validated changes

N/A

