### PR TITLE
Remove the build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 <p align="center"><img src="assets/logo.png" alt="Logo" width="250px" /></p>
 <p align="center">
-<a href="https://github.com/cert-manager/aws-privateca-issuer/actions">
-<img alt="Build Status" src="https://github.com/cert-manager/aws-privateca-issuer/workflows/CI/badge.svg" />
-</a>
 <a href="https://goreportcard.com/report/github.com/cert-manager/aws-privateca-issuer">
-<img alt="Build Status" src="https://goreportcard.com/badge/github.com/cert-manager/aws-privateca-issuer" />
+<img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/cert-manager/aws-privateca-issuer" />
 </a>
 <img alt="Latest version" src="https://img.shields.io/github/v/release/cert-manager/aws-privateca-issuer?color=success&sort=semver" />
 </p>


### PR DESCRIPTION
### Issue # (if applicable)

https://github.com/cert-manager/aws-privateca-issuer/issues/411

### Reason for this change

The build badge is broken due to a README markdown bug. However, in it's current state, it is not providing a lot of documentation value - it just points to the previous run of the "release" workflow. We will remove it and re-evaluate adding back a badge later that adds more value and better represents the build status.

### Description of changes

Removing the badge from the markdown.

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced ? -->

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

