### PR TITLE
Set on-release.yml to trigger on release publishing instead of push

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,8 +1,7 @@
 name: Release
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types: [published]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

Previously, this workflow triggered on a push with any tag. This was causing a weird edge case where workflows that were triggered on a forked branch of the repository with a release cut to it would show up on the parent repo.

If we change this workflow to trigger instead on the actual publishing of a release, this behavior should stop.

### Description of changes

The workflow only triggers when a release is published, instead of when a push with a tag happens.

https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=published#release

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

Tested by:
- Creating a fork of https://github.com/ARichman555 here: https://github.com/hanleyyin/ratchat
  - This is because I can't create a fork of my own repos
- Then, I made an Action to trigger on publish as well: https://github.com/hanleyyin/ratchat/blob/main/.github/workflows/on-release.yml, and cut a release on my fork. 
  - Saw the corresponding Action in my fork 
- Made a PR to ensure the parent repo also had the same action
  - Confirmed that when the parent repo made a release (v0.0.1), the Action is visible from the parent repo.
- Made a secondary branch, cut a release to it (triggering an Action run on the fork), and made a PR
  - Confirmed that this run is not visible from the parent