### PR TITLE
Add support for extraContainers

### DIFF
--- a/.github/workflows/on-safe-to-test-label.yml
+++ b/.github/workflows/on-safe-to-test-label.yml
@@ -178,6 +178,22 @@ jobs:
         if: ${{ always() }}
         run: |
           make kind-cluster-delete
+      - name: Run test cases with IAMRA
+        if: ${{ always() }}
+        run: |
+          ./e2e/iamra-test/test.sh
+          make e2etest
+      - name: Copy Kind logs to S3
+        if: ${{ always() }}
+        run: |
+          mkdir logs-iamra-test
+          export E2E_ARTIFACTS_DIRECTORY=logs-iamra-test
+          make kind-export-logs
+          aws s3 cp --recursive logs-iamra-test s3://aws-privateca-issuer-k8s-logs-test-us-east-1/${{ needs.start-runner.outputs.ec2-instance-id }}-logs-iamra-test/
+      - name: Terminate Kind cluster
+        if: ${{ always() }}
+        run: |
+          make kind-cluster-delete
       - name: Run helm test
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'chart update') && inputs.architecture != 'arm64' }}
         run: |

--- a/charts/aws-pca-issuer/templates/deployment.yaml
+++ b/charts/aws-pca-issuer/templates/deployment.yaml
@@ -85,6 +85,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
+      {{- if .Values.extraContainers }}
+        {{- toYaml .Values.extraContainers | nindent 8 }}
+      {{- end }}
       {{- if .Values.volumes }}
       volumes:
         {{ toYaml .Values.volumes | nindent 6 }}

--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -154,6 +154,9 @@ volumes: []
 # Additional VolumeMounts on the operator container.
 volumeMounts: []
 
+# Extra containers to add to the pod spec in the deployment.
+extraContainers: []
+
 # Configures a disruption budget for the deployment.
 #
 # Expects input structure similar to https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#poddisruptionbudgetspec-v1-policy

--- a/e2e/iamra-test/iamra-values.yaml
+++ b/e2e/iamra-test/iamra-values.yaml
@@ -1,0 +1,36 @@
+serviceAccount:
+  create: false
+
+image:
+  repository: localhost:5000/aws-privateca-issuer
+  tag: latest
+  pullPolicy: Always
+
+env:
+  AWS_EC2_METADATA_SERVICE_ENDPOINT: "http://127.0.0.1:9911"
+
+extraContainers:
+  - name: "rolesanywhere-credential-helper"
+    image: "public.ecr.aws/rolesanywhere/credential-helper:latest"
+    command: ["aws_signing_helper"]
+    args:
+      - "serve"
+      - "--private-key"
+      - "/etc/cert/tls.key"
+      - "--certificate"
+      - "/etc/cert/tls.crt"
+      - "--role-arn"
+      - "$ROLE_ARN"
+      - "--profile-arn"
+      - "$PROFILE_ARN"
+      - "--trust-anchor-arn"
+      - "$TRUST_ANCHOR_ARN"
+    volumeMounts:
+      - name: cert
+        mountPath: /etc/cert/
+        readOnly: true
+
+volumes:
+  - name: cert
+    secret:
+      secretName: cert

--- a/e2e/iamra-test/test.sh
+++ b/e2e/iamra-test/test.sh
@@ -1,0 +1,34 @@
+set -euo pipefail
+
+CA_ARN=$(aws ssm  get-parameter --name /iamra/certificate-authority-arn | jq -r '.Parameter.Value')
+TRUST_ANCHOR_ARN=$(aws ssm  get-parameter --name /iamra/trust-anchor-arn | jq -r '.Parameter.Value')
+PROFILE_ARN=$(aws ssm  get-parameter --name /iamra/profile-arn | jq -r '.Parameter.Value')
+ROLE_ARN=$(aws ssm  get-parameter --name /iamra/role-arn | jq -r '.Parameter.Value')
+
+openssl req -out iamra.csr -new -newkey rsa:2048 -nodes -keyout iamra.key -subj "/CN=iamra-issuer"
+
+CERT_ARN=$(aws acm-pca issue-certificate \
+      --certificate-authority-arn $CA_ARN \
+      --csr fileb://iamra.csr \
+      --signing-algorithm "SHA256WITHRSA" \
+      --validity Value=1,Type="DAYS" | jq -r .CertificateArn)
+
+aws acm-pca get-certificate \
+      --certificate-authority-arn $CA_ARN \
+      --certificate-arn $CERT_ARN | \
+      jq -r .Certificate > iamra-cert.pem
+
+PROFILE_ARN=$PROFILE_ARN ROLE_ARN=$ROLE_ARN TRUST_ANCHOR_ARN=$TRUST_ANCHOR_ARN envsubst <e2e/iamra-test/iamra-values.yaml >replaced-values.yaml
+
+make manager
+make create-local-registry
+make kind-cluster
+make deploy-cert-manager
+make docker-build
+make docker-push-local
+
+kubectl create secret tls -n aws-privateca-issuer cert --cert=iamra-cert.pem --key=iamra.key
+
+sleep 15
+
+helm install issuer ./charts/aws-pca-issuer -f replaced-values.yaml -n aws-privateca-issuer


### PR DESCRIPTION
This adds support for declaring additional containers as part of the pod spec in the deployment. 

### Reason for this change

The driving use case here is to allow us to deploy the
[aws_signing_helper](https://github.com/aws/rolesanywhere-credential-helper) in "serve" mode as a sidecar, so we can use the AWS PCA Issuer with IAM Roles Anywhere.

### Description of changes

Helm change only. This is a somewhat standard parameter that is supported by other open source projects. Example: https://github.com/kubernetes/ingress-nginx/blob/9dc73d17c76e2289408ebff2f3446b8b13c3e72e/charts/ingress-nginx/values.yaml#L673

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

```
$ cat extraContainer.yaml
extraContainers:
  - name: "iam-roles-anywhere-sidecar"
    image: "foo"
    resources:
      limits:
        cpu: '100m'
        memory: 100Mi
      requests:
        cpu: '100m'
        memory: 100Mi
$ diff -u <(helm template "foo" . -f extraContainer.yaml) <(helm template "foo" .)
--- /dev/fd/63	2025-07-07 15:27:34
+++ /dev/fd/62	2025-07-07 15:27:34
@@ -294,15 +294,6 @@
             requests:
               cpu: 50m
               memory: 64Mi
-        - image: foo
-          name: iam-roles-anywhere-sidecar
-          resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-            requests:
-              cpu: 100m
-              memory: 100Mi
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
````

