### PR TITLE
Support annotations in helm chart

### DIFF
--- a/charts/aws-pca-issuer/templates/deployment.yaml
+++ b/charts/aws-pca-issuer/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-privateca-issuer.labels" . | nindent 4 }}
+  {{- if .Values.annotations }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -3,6 +3,9 @@
 # Number of replicas to run of the issuer
 replicaCount: 2
 
+# Annotations to be added to the Deployment Resource
+annotations: {}
+
 image:
   # Image repository
   repository: public.ecr.aws/k1n1h4h4/cert-manager-aws-privateca-issuer


### PR DESCRIPTION
This is related to
https://github.com/cert-manager/aws-privateca-issuer/pull/416. To use IAM Roles Anywhere, we will have a client certificate managed by a different cert-manager issuer. To reload the certificate when it is renewed, we need to be able to set annotations on the deployment (to make use of https://github.com/stakater/Reloader).

Validation:

```
$ helm template "foo" . --show-only templates/deployment.yaml  | head -n 20
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo-aws-privateca-issuer
  namespace: default
  labels:
    helm.sh/chart: aws-privateca-issuer-v1.6.0
    app.kubernetes.io/name: aws-privateca-issuer
    app.kubernetes.io/instance: foo
    app.kubernetes.io/version: "v1.6.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 2
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 1
  revisionHistoryLimit: 10
$ cat annotation.yaml
annotations:
  foo: bar
$ helm template "foo" . -f annotation.yaml --show-only templates/deployment.yaml  | head -n 20
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo-aws-privateca-issuer
  namespace: default
  labels:
    helm.sh/chart: aws-privateca-issuer-v1.6.0
    app.kubernetes.io/name: aws-privateca-issuer
    app.kubernetes.io/instance: foo
    app.kubernetes.io/version: "v1.6.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
    foo: bar
spec:
  replicas: 2
  strategy:
    type: RollingUpdate
    rollingUpdate:
```

### Reason for this change

See above

### Description of changes

See above

### Describe any new or updated permissions being added

None

### Description of how you validated changes

See above
