### PR TITLE
[Helm] Support set image with digest

### DIFF
--- a/charts/aws-pca-issuer/README.md
+++ b/charts/aws-pca-issuer/README.md
@@ -77,7 +77,24 @@ IfNotPresent
 <td>image.tag</td>
 <td>
 
-Image tag
+Image tag (used only when digest is empty)
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+""
+```
+
+</td>
+</tr>
+<tr>
+
+<td>image.digest</td>
+<td>
+
+Image digest (overrides tag when set). Example: sha256:aaaaaa...
 
 </td>
 <td>string</td>

--- a/charts/aws-pca-issuer/templates/deployment.yaml
+++ b/charts/aws-pca-issuer/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- else }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /manager

--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -8,9 +8,10 @@ image:
   repository: public.ecr.aws/k1n1h4h4/cert-manager-aws-privateca-issuer
   # Image pull policy
   pullPolicy: IfNotPresent
-  # Image tag
+  # Image tag (used only when digest is empty)
   tag: ""
-
+  # Image digest (overrides tag when set). Example: sha256:aaaaaa...
+  digest: ""
 # Disable waiting for CertificateRequests to be Approved before signing
 disableApprovedCheck: false
 


### PR DESCRIPTION
### Reason for this change
Specifying container images by digest in the Helm Chart.
Using digests ensures immutability and reproducibility of deployments, providing stronger security and reliability in production environments. Previously, only tag could be used to specify the image, but now when a digest value is provided, it will take precedence over the tag.

### Description of changes
- Support set image with digest

<!--
What code changes did you make?
Have you made any important design decisions?
What use cases does this change enable?
-->

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced ? -->

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

