### PR TITLE
Pass in VPC instead of Subnet to ec2-github-runner

### DIFF
--- a/.github/workflows/on-safe-to-test-label.yml
+++ b/.github/workflows/on-safe-to-test-label.yml
@@ -32,22 +32,21 @@ jobs:
         run: |
           AWS_REGION=us-east-1
           VPC_ID=$(aws ec2 describe-vpcs --filters 'Name=tag-key,Values=GithubActionsTesting' --query 'Vpcs[0].VpcId' --output text)
-          SUBNET_ID=$(aws ec2 describe-subnets --filters "Name=vpc-id,Values=$VPC_ID" "Name=tag-key,Values=GithubActionsTesting"  --query 'Subnets[0].SubnetId' --output text)
           SG_ID=$(aws ec2 describe-security-groups --filters "Name=vpc-id,Values=$VPC_ID" "Name=tag-key,Values=GithubActionsTesting" --query 'SecurityGroups[0].GroupId' --output text)
           AMI=$(aws ssm get-parameter --name /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-${{ inputs.architecture }} --query 'Parameter.Value' --output text)
           echo AWS_REGION=$AWS_REGION >> $GITHUB_ENV
-          echo SUBNET_ID=$SUBNET_ID >> $GITHUB_ENV
+          echo VPC_ID=$VPC_ID >> $GITHUB_ENV
           echo SG_ID=$SG_ID >> $GITHUB_ENV
           echo AMI=$AMI >> $GITHUB_ENV
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: aws-pca-k8s-plugin-ops-admin/ec2-github-runner@0444f5f46462bcf8d98932bc807d2f51c4945b58
+        uses: aws-pca-k8s-plugin-ops-admin/ec2-github-runner@001b8975c07ebdbc838650b9ff7635735f915c5f
         with:
           mode: start
           github-token: GithubToken-test-us-east-1
           ec2-image-id: ${{ env.AMI }}
           ec2-instance-type: ${{ env.EC2_INSTANCE_TYPE }}
-          subnet-id: ${{ env.SUBNET_ID }}
+          vpc-id: ${{ env.VPC_ID }}
           security-group-id: ${{ env.SG_ID }}
           iam-role-name: K8sPluginInstanceProfile-test-us-east-1
           ec2-launch-template: GithubRunnerLaunchTemplate-test-us-east-1
@@ -244,7 +243,7 @@ jobs:
           AWS_REGION=us-east-1
           echo AWS_REGION=$AWS_REGION >> $GITHUB_ENV
       - name: Stop EC2 runner
-        uses: aws-pca-k8s-plugin-ops-admin/ec2-github-runner@0444f5f46462bcf8d98932bc807d2f51c4945b58
+        uses: aws-pca-k8s-plugin-ops-admin/ec2-github-runner@001b8975c07ebdbc838650b9ff7635735f915c5f
         with:
           mode: stop
           github-token: GithubToken-test-us-east-1


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

There is an issue where there is not enough capacity in an AZ to provision a new EC2 instance to act as our GitHub runner. We updated the ec2-github-runner package to instead take in a vpc-id and will loop over all available subnets (which are in different AZs) until one succeeds or they all fail. This should make our e2e tests less flaky.

### Description of changes

* Swapped subnet-id to vpc-id instead
* Updated the commit of the ec2-github-runner package to the latest https://github.com/aws-pca-k8s-plugin-ops-admin/ec2-github-runner/commit/001b8975c07ebdbc838650b9ff7635735f915c5f

### Describe any new or updated permissions being added

None

### Description of how you validated changes

* Tested on fork

