### PR TITLE
Add assume role for Issuer

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,24 @@ volumes:
       secretName: cert
 ```
 
+#### Cross Account Assume Role
+
+You can configure the AWS Private CA issuer to assume an IAM role before making AWS Private CA API calls. This method provides flexibility for various authentication scenarios and is an alternative to AWS Resource Access Manager (RAM) sharing for cross-account use cases.
+
+When you specify a role in the `role` field, the issuer assumes that role using AWS Security Token Service (STS) before making AWS Private CA API calls.
+
+Example:
+```
+apiVersion: awspca.cert-manager.io/v1beta1
+kind: AWSPCAClusterIssuer
+metadata:
+  name: example
+spec:
+  arn: <some-pca-arn>
+  role: <some-role-arn>
+  region: <some-region>
+```
+
 ## Supported workflows
 
 AWS Private Certificate Authority(PCA) Issuer Plugin supports the following integrations and use cases:

--- a/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaclusterissuers.yaml
+++ b/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaclusterissuers.yaml
@@ -46,6 +46,9 @@ spec:
               region:
                 description: Should contain the AWS region if it cannot be inferred
                 type: string
+              role:
+                description: Specifies the ARN of role to assume when issuing certificates.
+                type: string
               secretRef:
                 description: Needs to be specified if you want to authorize with AWS
                   using an access and secret key

--- a/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaissuers.yaml
+++ b/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaissuers.yaml
@@ -45,6 +45,9 @@ spec:
               region:
                 description: Should contain the AWS region if it cannot be inferred
                 type: string
+              role:
+                description: Specifies the ARN of role to assume when issuing certificates.
+                type: string
               secretRef:
                 description: Needs to be specified if you want to authorize with AWS
                   using an access and secret key

--- a/config/crd/bases/awspca.cert-manager.io_awspcaclusterissuers.yaml
+++ b/config/crd/bases/awspca.cert-manager.io_awspcaclusterissuers.yaml
@@ -46,6 +46,9 @@ spec:
               region:
                 description: Should contain the AWS region if it cannot be inferred
                 type: string
+              role:
+                description: Specifies the ARN of role to assume when issuing certificates.
+                type: string
               secretRef:
                 description: Needs to be specified if you want to authorize with AWS
                   using an access and secret key

--- a/config/crd/bases/awspca.cert-manager.io_awspcaissuers.yaml
+++ b/config/crd/bases/awspca.cert-manager.io_awspcaissuers.yaml
@@ -45,6 +45,9 @@ spec:
               region:
                 description: Should contain the AWS region if it cannot be inferred
                 type: string
+              role:
+                description: Specifies the ARN of role to assume when issuing certificates.
+                type: string
               secretRef:
                 description: Needs to be specified if you want to authorize with AWS
                   using an access and secret key

--- a/config/examples/cluster-issuer-with-assumption-role/issuer.yaml
+++ b/config/examples/cluster-issuer-with-assumption-role/issuer.yaml
@@ -1,0 +1,8 @@
+apiVersion: awspca.cert-manager.io/v1beta1
+kind: AWSPCAClusterIssuer
+metadata:
+  name: example
+spec:
+  arn: <some-pca-arn>
+  role: <some-role-arn>
+  region: us-west-2

--- a/e2e/aws_helpers.go
+++ b/e2e/aws_helpers.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/acmpca"
@@ -296,7 +295,7 @@ func getAccountID(ctx context.Context, cfg aws.Config) string {
 	return *callerID.Account
 }
 
-func getPartition(ctx context.Context, cfg aws.Config) string {
+func getCallerIdentity(ctx context.Context, cfg aws.Config) *sts.GetCallerIdentityOutput {
 	stsClient := sts.NewFromConfig(cfg)
 
 	callerID, callerErr := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
@@ -305,12 +304,7 @@ func getPartition(ctx context.Context, cfg aws.Config) string {
 		panic(callerErr.Error())
 	}
 
-	parsedArn, parseErr := arn.Parse(*callerID.Arn)
-	if parseErr != nil {
-		return "aws"
-	}
-
-	return parsedArn.Partition
+	return callerID
 }
 
 func assumeRole(ctx context.Context, cfg aws.Config, roleName string, region string) aws.Config {

--- a/e2e/clusterissuer_steps.go
+++ b/e2e/clusterissuer_steps.go
@@ -13,13 +13,22 @@ import (
 )
 
 func (issCtx *IssuerContext) createClusterIssuer(ctx context.Context, caType string) error {
+	return issCtx.createClusterIssuerWithSpec(ctx, caType, getIssuerSpec(caType))
+}
+
+func (issCtx *IssuerContext) createClusterIssuerWithRole(ctx context.Context) error {
+	return issCtx.createClusterIssuerWithSpec(ctx, "RSA", getIssuerSpecWithRole("RSA"))
+}
+
+func (issCtx *IssuerContext) createClusterIssuerWithSpec(ctx context.Context, caType string, spec v1beta1.AWSPCAIssuerSpec) error {
 	if issCtx.issuerName == "" {
 		issCtx.issuerName = uuid.New().String() + "--cluster-issuer--" + strings.ToLower(caType)
 	}
+
 	issCtx.issuerType = "AWSPCAClusterIssuer"
 	issSpec := v1beta1.AWSPCAClusterIssuer{
 		ObjectMeta: metav1.ObjectMeta{Name: issCtx.issuerName},
-		Spec:       getIssuerSpec(caType),
+		Spec:       spec,
 	}
 
 	if issCtx.secretRef != (v1beta1.AWSCredentialsSecretReference{}) {

--- a/e2e/common_steps.go
+++ b/e2e/common_steps.go
@@ -34,6 +34,12 @@ func getIssuerSpec(caType string) v1beta1.AWSPCAIssuerSpec {
 	}
 }
 
+func getIssuerSpecWithRole(caType string) v1beta1.AWSPCAIssuerSpec {
+	spec := getIssuerSpec(caType)
+	spec.Role = testContext.roleToAssume
+	return spec
+}
+
 func (issCtx *IssuerContext) createNamespace(ctx context.Context) error {
 	namespaceName := "pca-issuer-ns-" + uuid.New().String()
 	namespace := v1.Namespace{

--- a/e2e/features/role_assumption.feature
+++ b/e2e/features/role_assumption.feature
@@ -1,0 +1,15 @@
+@RoleAssumption
+Feature: Issue certificates using role assumption
+  As a user of the aws-privateca-issuer
+  I need to be able to issue certificates using role assumption
+
+  Scenario: Issue a certificate with a ClusterIssuer using role assumption
+    Given I create an AWSPCAClusterIssuer with role assumption
+    When I issue a RSA certificate
+    Then the certificate should be issued successfully
+
+  Scenario: Issue a certificate with a namespaced Issuer using role assumption
+    Given I create a namespace
+    And I create an AWSPCAIssuer with role assumption
+    When I issue a RSA certificate
+    Then the certificate should be issued successfully

--- a/e2e/namespaceissuer_steps.go
+++ b/e2e/namespaceissuer_steps.go
@@ -13,11 +13,19 @@ import (
 )
 
 func (issCtx *IssuerContext) createNamespaceIssuer(ctx context.Context, caType string) error {
+	return issCtx.createNamespaceIssuerWithSpec(ctx, caType, getIssuerSpec(caType))
+}
+
+func (issCtx *IssuerContext) createNamespaceIssuerWithRole(ctx context.Context) error {
+	return issCtx.createNamespaceIssuerWithSpec(ctx, "RSA", getIssuerSpecWithRole("RSA"))
+}
+
+func (issCtx *IssuerContext) createNamespaceIssuerWithSpec(ctx context.Context, caType string, spec v1beta1.AWSPCAIssuerSpec) error {
 	issCtx.issuerName = uuid.New().String() + "--namespace-issuer--" + strings.ToLower(caType)
 	issCtx.issuerType = "AWSPCAIssuer"
 	issSpec := v1beta1.AWSPCAIssuer{
 		ObjectMeta: metav1.ObjectMeta{Name: issCtx.issuerName},
-		Spec:       getIssuerSpec(caType),
+		Spec:       spec,
 	}
 
 	if issCtx.secretRef != (v1beta1.AWSCredentialsSecretReference{}) {

--- a/pkg/api/v1beta1/awspcaissuer_types.go
+++ b/pkg/api/v1beta1/awspcaissuer_types.go
@@ -37,6 +37,9 @@ type AWSPCAIssuerSpec struct {
 	// Needs to be specified if you want to authorize with AWS using an access and secret key
 	// +optional
 	SecretRef AWSCredentialsSecretReference `json:"secretRef,omitempty"`
+	// Specifies the ARN of role to assume when issuing certificates.
+	// +optional
+	Role string `json:"role,omitempty"`
 }
 
 // AWSCredentialsSecretReference defines the secret used by the issuer


### PR DESCRIPTION
### Issue # 361

Closes # [361](https://github.com/cert-manager/aws-privateca-issuer/issues/361)

### Reason for this change

AWS RAM has restrictions that disallow issuing `isCA: true` certs from Subordinate AWS PCA. 
see https://docs.aws.amazon.com/privateca/latest/userguide/UsingTemplates.html

However, for example, Linkerd requires such a certificate.

This pull request allows for requesting an issue certificate directly from AWS PCA that is located in a different account. 

### Description of changes

A new optional field 'role' was added to Issuer and ClusterIssuer CRDs, which allows assuming a role for another account and working with AWS PCA from a different account.
