### PR TITLE
Add namespace to HorizontalPodAutoscaler metadata

### DIFF
--- a/charts/aws-pca-issuer/templates/hpa.yaml
+++ b/charts/aws-pca-issuer/templates/hpa.yaml
@@ -7,6 +7,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "aws-privateca-issuer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-privateca-issuer.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
### Issue: https://github.com/cert-manager/aws-privateca-issuer/issues/437

Currently the HPA doesn't match the release namespace so when it gets created, it goes into the default namespace.

We know make sure it get's set to the release namespace like all the other resources created via the helm chart.

## Testing

Change was testing on this fork via automated helm testing: https://github.com/ARichman555/aws-privateca-issuer 
