### PR TITLE
Update e2e tests to verify certificate extended key usage

### DIFF
--- a/e2e/awspcaissuer_test.go
+++ b/e2e/awspcaissuer_test.go
@@ -42,6 +42,7 @@ type IssuerContext struct {
 	issuerType string
 	namespace  string
 	secretRef  v1beta1.AWSCredentialsSecretReference
+	certConfig CertificateConfig
 }
 
 var opts = godog.Options{
@@ -222,8 +223,9 @@ func InitializeTestSuite(suiteCtx *godog.TestSuiteContext) {
 func InitializeScenario(ctx *godog.ScenarioContext) {
 	// This initializes the IssuerContext struct for each test
 	issuerContext := &IssuerContext{
-		namespace: "default",
-		secretRef: v1beta1.AWSCredentialsSecretReference{},
+		namespace:  "default",
+		secretRef:  v1beta1.AWSCredentialsSecretReference{},
+		certConfig: defaultCertConfig(),
 	}
 
 	// This defines the mapping of steps --> functions
@@ -234,10 +236,16 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I delete the AWSPCAClusterIssuer$`, issuerContext.deleteClusterIssuer)
 	ctx.Step(`^I create an AWSPCAIssuer using a (RSA|ECDSA|XA) CA$`, issuerContext.createNamespaceIssuer)
 	ctx.Step(`^I create an AWSPCAIssuer with role assumption$`, issuerContext.createNamespaceIssuerWithRole)
-	ctx.Step(`^I issue a (SHORT_VALIDITY|RSA|ECDSA|CA) certificate$`, issuerContext.issueCertificate)
+	ctx.Step(`^I update my certificate spec to issue a CA certificate$`, issuerContext.setCAConfig)
+	ctx.Step(`^I update my certificate spec to issue a (RSA|ECDSA) certificate$`, issuerContext.setKeyAlgorithmConfig)
+	ctx.Step(`^I update my certificate spec to issue a certificate with duration of (\d+) hours$`, issuerContext.setDurationConfig)
+	ctx.Step(`^I update my certificate spec to issue a certificate with renew before of (\d+) hours$`, issuerContext.setRenewBeforeConfig)
+	ctx.Step(`^I update my certificate spec to issue a certificate with usages of (.+)$`, issuerContext.setUsagesConfig)
+	ctx.Step(`^I issue the certificate$`, issuerContext.issueConfiguredCertificate)
 	ctx.Step(`^the certificate should be issued successfully$`, issuerContext.verifyCertificateIssued)
 	ctx.Step(`^the certificate request has been created$`, issuerContext.verifyCertificateRequestIsCreated)
 	ctx.Step(`^the certificate request has reason (Pending|Failed|Issued|Denied) and status (True|False|Unknown)$`, issuerContext.verifyCertificateRequestState)
+	ctx.Step(`^the certificate should be issued with usage (.+)$`, issuerContext.verifyCertificateContent)
 
 	// This cleans up all of the resources after a test
 	ctx.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
@@ -312,6 +320,10 @@ func GetErrorDetails(ctx context.Context, sc *godog.Scenario, issuerContext *Iss
 	errMsg += fmt.Sprintf("\nLogging Issuer conditions:\n")
 	for _, condition := range issuerConditions {
 		errMsg += fmt.Sprintf("Reason: %s, Status: %s, Message: %s\n", condition.Reason, condition.Status, condition.Message)
+	}
+
+	if len(issuerConditions) == 0 {
+		errMsg += "Issuer did not have any conditions. This most likely means there was an AWS permissions issue which prevented the issuer from entering a Ready state.\n"
 	}
 
 	crName := fmt.Sprintf("%s-%d", issuerContext.certName, 1)

--- a/e2e/common_steps.go
+++ b/e2e/common_steps.go
@@ -6,16 +6,53 @@ import (
 	"strings"
 	"time"
 
+	util "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cucumber/godog"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
+	"crypto/x509"
+	"encoding/pem"
+	"slices"
+
 	"github.com/cert-manager/aws-privateca-issuer/pkg/api/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+type CertificateConfig struct {
+	IsCA         bool
+	Duration     time.Duration
+	KeyAlgorithm string
+	RenewBefore  time.Duration
+	Usages       []cmv1.KeyUsage
+}
+
+const secretSuffix = "-cert-secret"
+
+var usageMap = map[string]cmv1.KeyUsage{
+	"client_auth":       cmv1.UsageClientAuth,
+	"server_auth":       cmv1.UsageServerAuth,
+	"digital_signature": cmv1.UsageDigitalSignature,
+	"code_signing":      cmv1.UsageCodeSigning,
+	"ocsp_signing":      cmv1.UsageOCSPSigning,
+	"any":               cmv1.UsageAny,
+	"email protection":  cmv1.UsageEmailProtection,
+	"ipsec user":        cmv1.UsageIPsecUser,
+	"ipsec tunnel":      cmv1.UsageIPsecTunnel,
+}
+
+func defaultCertConfig() CertificateConfig {
+	return CertificateConfig{
+		IsCA:         false,
+		KeyAlgorithm: "RSA",
+		Duration:     721,
+		RenewBefore:  240,
+		Usages:       []cmv1.KeyUsage{cmv1.UsageClientAuth, cmv1.UsageServerAuth},
+	}
+}
 
 func getCaArn(caType string) string {
 	caArn, exists := testContext.caArns[caType]
@@ -98,75 +135,72 @@ func (issCtx *IssuerContext) createSecret(ctx context.Context, accessKey string,
 	return nil
 }
 
-func getBaseCertSpec(certType string) cmv1.CertificateSpec {
-	sanitizedCertType := strings.Replace(strings.ToLower(certType), "_", "-", -1)
+func getCertSpec(ctx context.Context, certConfig CertificateConfig) cmv1.CertificateSpec {
+	sanitizedCertType := strings.Replace(strings.ToLower(certConfig.KeyAlgorithm), "_", "-", -1)
+
 	certSpec := cmv1.CertificateSpec{
+		IsCA: certConfig.IsCA,
 		Subject: &cmv1.X509Subject{
 			Organizations: []string{"aws"},
 		},
 		DNSNames: []string{sanitizedCertType + "-cert.aws.com"},
 		Duration: &metav1.Duration{
-			Duration: 721 * time.Hour,
+			Duration: certConfig.Duration * time.Hour,
 		},
-		Usages: []cmv1.KeyUsage{cmv1.UsageClientAuth, cmv1.UsageServerAuth},
+		RenewBefore: &metav1.Duration{
+			Duration: certConfig.RenewBefore * time.Hour,
+		},
+		Usages: certConfig.Usages,
 	}
 
-	if certType == "RSA" {
+	switch certConfig.KeyAlgorithm {
+	case "RSA":
 		certSpec.PrivateKey = &cmv1.CertificatePrivateKey{
 			Algorithm: cmv1.RSAKeyAlgorithm,
 			Size:      2048,
 		}
-	}
-
-	if certType == "ECDSA" {
+	case "ECDSA":
 		certSpec.PrivateKey = &cmv1.CertificatePrivateKey{
 			Algorithm: cmv1.ECDSAKeyAlgorithm,
 			Size:      256,
 		}
-	}
-
-	return certSpec
-}
-
-func getCertSpec(certType string) cmv1.CertificateSpec {
-	switch certType {
-	case "RSA":
-		return getBaseCertSpec(certType)
-	case "ECDSA":
-		return getBaseCertSpec(certType)
-
-	// For simplicity, we use RSA as the base for these. This can be further generalized if desired.
-	case "SHORT_VALIDITY":
-		return getCertSpecWithValidity(getBaseCertSpec("RSA"), 20, 5)
-	case "CA":
-		return getCaCertSpec(getBaseCertSpec("RSA"))
 	default:
-		panic(fmt.Sprintf("Unknown Certificate Type: %s", certType))
-	}
-}
-
-func getCertSpecWithValidity(certSpec cmv1.CertificateSpec, duration time.Duration, renewBefore time.Duration) cmv1.CertificateSpec {
-	certSpec.Duration = &metav1.Duration{
-		Duration: duration * time.Hour,
-	}
-	certSpec.RenewBefore = &metav1.Duration{
-		Duration: renewBefore * time.Hour,
+		assert.FailNow(godog.T(ctx), "Unknown certificate key algorithm: "+certConfig.KeyAlgorithm)
 	}
 
 	return certSpec
 }
 
-func getCaCertSpec(certSpec cmv1.CertificateSpec) cmv1.CertificateSpec {
-	certSpec.IsCA = true
-	return getCertSpecWithValidity(certSpec, 20, 5)
+func (issCtx *IssuerContext) setCAConfig() {
+	issCtx.certConfig.IsCA = true
 }
 
-func (issCtx *IssuerContext) issueCertificate(ctx context.Context, certType string) error {
-	sanitizedCertType := strings.Replace(strings.ToLower(certType), "_", "-", -1)
-	issCtx.certName = issCtx.issuerName + "-" + sanitizedCertType + "-cert"
-	certSpec := getCertSpec(certType)
+func (issCtx *IssuerContext) setKeyAlgorithmConfig(keyAlgorithm string) {
+	issCtx.certConfig.KeyAlgorithm = keyAlgorithm
+}
 
-	secretName := issCtx.certName + "-cert-secret"
+func (issCtx *IssuerContext) setDurationConfig(duration int) {
+	issCtx.certConfig.Duration = time.Duration(duration)
+}
+
+func (issCtx *IssuerContext) setRenewBeforeConfig(renewBefore int) {
+	issCtx.certConfig.RenewBefore = time.Duration(renewBefore)
+}
+
+func (issCtx *IssuerContext) setUsagesConfig(usageStr string) {
+	issCtx.certConfig.Usages = parseUsages(usageStr)
+}
+
+func (issCtx *IssuerContext) issueConfiguredCertificate(ctx context.Context) error {
+	return issCtx.issueCertificate(ctx, issCtx.certConfig)
+}
+
+func (issCtx *IssuerContext) issueCertificate(ctx context.Context, certConfig CertificateConfig) error {
+	sanitizedCertType := strings.Replace(strings.ToLower(certConfig.KeyAlgorithm), "_", "-", -1)
+	issCtx.certName = issCtx.issuerName + "-" + sanitizedCertType + "-cert"
+	certSpec := getCertSpec(ctx, certConfig)
+
+	secretName := issCtx.certName + secretSuffix
 	certSpec.SecretName = secretName
 	certSpec.IssuerRef = cmmeta.ObjectReference{
 		Kind:  issCtx.issuerType,
@@ -186,6 +220,20 @@ func (issCtx *IssuerContext) issueCertificate(ctx context.Context, certType stri
 	}
 
 	return nil
+}
+
+func parseUsages(usageStr string) []cmv1.KeyUsage {
+	parts := strings.Split(usageStr, ",")
+	var usages []cmv1.KeyUsage
+	for _, part := range parts {
+		if usage, exists := usageMap[strings.ToLower(part)]; exists {
+			usages = append(usages, usage)
+		} else {
+			usages = append(usages, cmv1.KeyUsage(part))
+		}
+	}
+
+	return usages
 }
 
 func (issCtx *IssuerContext) verifyCertificateIssued(ctx context.Context) error {
@@ -219,6 +267,43 @@ func (issCtx *IssuerContext) verifyCertificateRequestState(ctx context.Context, 
 
 	if err != nil {
 		assert.FailNow(godog.T(ctx), "Certificate Request did not reach specified state, Condition = "+reason+", Status = "+status+": "+err.Error())
+	}
+
+	return nil
+}
+
+func (issCtx *IssuerContext) verifyCertificateContent(ctx context.Context, usage string) error {
+	secretName := issCtx.certName + secretSuffix
+
+	certBytes, err := getCertificateData(ctx, testContext.clientset, issCtx.namespace, secretName)
+	if err != nil {
+		assert.FailNow(godog.T(ctx), "Failed to get certificate data: "+err.Error())
+	}
+
+	if len(certBytes) == 0 {
+		assert.FailNow(godog.T(ctx), "Certificate data is empty")
+	}
+
+	decodedData, _ := pem.Decode(certBytes)
+	if decodedData == nil {
+		assert.FailNow(godog.T(ctx), "Failed to decode certificate data")
+	}
+
+	cert, err := x509.ParseCertificate(decodedData.Bytes)
+	if err != nil {
+		assert.FailNow(godog.T(ctx), "Failed to parse certificate: "+err.Error())
+	}
+
+	for _, expectedUsage := range strings.Split(usage, ",") {
+		mappedUsage, exists := usageMap[expectedUsage]
+		if !exists {
+			assert.FailNow(godog.T(ctx), "Expected usage %q not found in usageMap.", expectedUsage)
+		}
+
+		x509Usage, _ := util.ExtKeyUsageType(mappedUsage)
+		if !slices.Contains(cert.ExtKeyUsage, x509Usage) {
+			assert.FailNow(godog.T(ctx), fmt.Sprintf("Certificate usage mismatch. Found: %v, Expected: %v", cert.ExtKeyUsage, mappedUsage))
+		}
 	}
 
 	return nil

--- a/e2e/features/cluster_issuer.feature
+++ b/e2e/features/cluster_issuer.feature
@@ -5,55 +5,96 @@ Feature: Issue certificates using an AWSPCAClusterIssuer
 
   Scenario Outline: Issue a certificate with a ClusterIssuer
     Given I create an AWSPCAClusterIssuer using a <caType> CA
-    When I issue a <certType> certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
     Then the certificate should be issued successfully
 
     Examples:
       | caType | certType       |
-      | RSA    | SHORT_VALIDITY |
       | RSA    | RSA            |
       | RSA    | ECDSA          |
-      | RSA    | CA             |
-      | ECDSA  | SHORT_VALIDITY |
       | ECDSA  | RSA            |
       | ECDSA  | ECDSA          |
-      | ECDSA  | CA             |
+
+  Scenario Outline: Issue a CA certificate with a ClusterIssuer
+    Given I create an AWSPCAClusterIssuer using a <caType> CA
+    And I update my certificate spec to issue a CA certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
+    Then the certificate should be issued successfully
+
+    Examples:
+      | caType | certType       |
+      | RSA    | RSA            |
+      | RSA    | ECDSA          |
+      | ECDSA  | RSA            |
+      | ECDSA  | ECDSA          |
+
+  Scenario Outline: Issue a short lived certificate with a ClusterIssuer
+    Given I create an AWSPCAClusterIssuer using a <caType> CA
+    And I update my certificate spec to issue a <certType> certificate
+    And I update my certificate spec to issue a certificate with duration of 20 hours
+    And I update my certificate spec to issue a certificate with renew before of 5 hours
+    When I issue the certificate
+    Then the certificate should be issued successfully
+
+    Examples:
+      | caType | certType       |
+      | RSA    | RSA            |
+      | RSA    | ECDSA          |
+      | ECDSA  | RSA            |
+      | ECDSA  | ECDSA          |
 
   @KubernetesSecrets
   Scenario Outline: Issue a certificate with a ClusterIssuer using a secret for AWS credentials
     Given I create a Secret with keys <accessKeyId> and <secretKeyId> for my AWS credentials
     And I create an AWSPCAClusterIssuer using a <caType> CA
-    When I issue a <certType> certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
     Then the certificate should be issued successfully
 
     Examples:
       | accessKeyId       | secretKeyId           | caType | certType       |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA    | SHORT_VALIDITY |
       | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA    | RSA            |
       | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA    | ECDSA          |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA    | CA             |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA  | SHORT_VALIDITY |
       | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA  | RSA            |
       | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA  | ECDSA          |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA  | CA             |
 
     @KeySelectors
     Examples:
       | accessKeyId       | secretKeyId           | caType | certType       |
-      | myKeyId           | mySecret              | RSA    | SHORT_VALIDITY |
       | myKeyId           | mySecret              | RSA    | RSA            |
       | myKeyId           | mySecret              | RSA    | ECDSA          |
-      | myKeyId           | mySecret              | RSA    | CA             |
-      | myKeyId           | mySecret              | ECDSA  | SHORT_VALIDITY |
       | myKeyId           | mySecret              | ECDSA  | RSA            |
       | myKeyId           | mySecret              | ECDSA  | ECDSA          |
-      | myKeyId           | mySecret              | ECDSA  | CA             |
+
+  @KeyUsage
+  Scenario Outline: Issue a certificate with specific key usage
+    Given I create an AWSPCAClusterIssuer using a <caType> CA
+    And I update my certificate spec to issue a <certType> certificate
+    And I update my certificate spec to issue a certificate with usages of <usage>
+    When I issue the certificate
+    Then the certificate should be issued successfully
+    Then the certificate should be issued with usage <usage>
+
+    Examples:
+      | caType | certType | usage                    |
+      | RSA    | RSA      | client_auth              |
+      | RSA    | RSA      | server_auth              |
+      | RSA    | RSA      | code_signing             |
+      | RSA    | RSA      | ocsp_signing             |
+      | RSA    | RSA      | any                      |
+      | RSA    | RSA      | server_auth,client_auth  |
+      | RSA    | RSA      | email protection         |
+      | RSA    | RSA      | ipsec user               |
+      | RSA    | RSA      | ipsec tunnel             |
 
   @CertificateRecovery
   Scenario: Issue a certificate with a non-existent issuer, is successfully issued after the issuer is created
     Given I create an AWSPCAClusterIssuer using a RSA CA
     And I delete the AWSPCAClusterIssuer
-    And I issue a RSA certificate
+    And I update my certificate spec to issue a RSA certificate
+    And I issue the certificate
     And the certificate request has been created
     And the certificate request has reason Pending and status False
     When I create an AWSPCAClusterIssuer using a RSA CA

--- a/e2e/features/cross_account.feature
+++ b/e2e/features/cross_account.feature
@@ -6,70 +6,197 @@ Feature: Issue certificates using a CA in another account
   @AWSPCAClusterIssuer
   Scenario Outline: Issue a certificate with a ClusterIssuer
     Given I create an AWSPCAClusterIssuer using a XA CA
-    When I issue a <certType> certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
     Then the certificate should be issued successfully
 
     Examples:
-      | certType       |
-      | SHORT_VALIDITY |
-      | RSA            |
-      | ECDSA          |
-      | CA             |
+      | certType |
+      | RSA      |
+      | ECDSA    |
+
+  @AWSPCAClusterIssuer
+  Scenario Outline: Issue a CA certificate with a ClusterIssuer
+    Given I create an AWSPCAClusterIssuer using a XA CA
+    And I update my certificate spec to issue a CA certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
+    Then the certificate should be issued successfully
+
+    Examples:
+      | certType |
+      | RSA      |
+      | ECDSA    |
+
+  @AWSPCAClusterIssuer
+  Scenario Outline: Issue a short lived certificate with a ClusterIssuer
+    Given I create an AWSPCAClusterIssuer using a XA CA
+    And I update my certificate spec to issue a <certType> certificate
+    And I update my certificate spec to issue a certificate with duration of 20 hours
+    And I update my certificate spec to issue a certificate with renew before of 5 hours
+    When I issue the certificate
+    Then the certificate should be issued successfully
+
+    Examples:
+      | certType |
+      | RSA      |
+      | ECDSA    |
 
   @AWSPCAClusterIssuer @KubernetesSecrets   
   Scenario Outline: Issue a certificate with a ClusterIssuer using a secret for AWS credentials
     Given I create a Secret with keys <accessKeyId> and <secretKeyId> for my AWS credentials
     And I create an AWSPCAClusterIssuer using a XA CA
-    When I issue a <certType> certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
     Then the certificate should be issued successfully
 
     Examples:
-      | accessKeyId       | secretKeyId           | certType      |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | SHORT_VALIDITY |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA            |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA          |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | CA             |
+      | accessKeyId       | secretKeyId           | certType |
+      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA      |
+      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA    |
 
     @KeySelectors
     Examples:
-      | accessKeyId       | secretKeyId           | certType      |
-      | myKeyId           | mySecret              | SHORT_VALIDITY |
-      | myKeyId           | mySecret              | RSA            |
-      | myKeyId           | mySecret              | ECDSA          |
-      | myKeyId           | mySecret              | CA             |
+      | accessKeyId       | secretKeyId           | certType |
+      | myKeyId           | mySecret              | RSA      |
+      | myKeyId           | mySecret              | ECDSA    |
+
+  @AWSPCAClusterIssuer @KubernetesSecrets
+  Scenario Outline: Issue a CA certificate with a ClusterIssuer using a secret for AWS credentials
+    Given I create a Secret with keys <accessKeyId> and <secretKeyId> for my AWS credentials
+    And I create an AWSPCAClusterIssuer using a XA CA
+    And I update my certificate spec to issue a CA certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
+    Then the certificate should be issued successfully
+
+    Examples:
+      | accessKeyId       | secretKeyId           | certType |
+      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA      |
+      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA    |
+
+    @KeySelectors
+    Examples:
+      | accessKeyId       | secretKeyId           | certType |
+      | myKeyId           | mySecret              | RSA      |
+      | myKeyId           | mySecret              | ECDSA    |
+
+  @AWSPCAClusterIssuer @KubernetesSecrets
+  Scenario Outline: Issue a short lived certificate with a ClusterIssuer using a secret for AWS credentials
+    Given I create a Secret with keys <accessKeyId> and <secretKeyId> for my AWS credentials
+    And I create an AWSPCAClusterIssuer using a XA CA
+    And I update my certificate spec to issue a <certType> certificate
+    And I update my certificate spec to issue a certificate with duration of 20 hours
+    And I update my certificate spec to issue a certificate with renew before of 5 hours
+    When I issue the certificate
+    Then the certificate should be issued successfully
+
+    Examples:
+      | accessKeyId       | secretKeyId           | certType |
+      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA      |
+      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA    |
+
+    @KeySelectors
+    Examples:
+      | accessKeyId       | secretKeyId           | certType |
+      | myKeyId           | mySecret              | RSA      |
+      | myKeyId           | mySecret              | ECDSA    |
 
   @AWSPCAIssuer
   Scenario Outline: Issue a certificate with a namespace issuer 
     Given I create an AWSPCAIssuer using a XA CA
-    When I issue a <certType> certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
     Then the certificate should be issued successfully
 
     Examples:
-      | certType       |
-      | SHORT_VALIDITY |
-      | RSA            |
-      | ECDSA          |
-      | CA             |
+      | certType |
+      | RSA      |
+      | ECDSA    |
+
+  @AWSPCAIssuer
+  Scenario Outline: Issue a CA certificate with a namespace issuer 
+    Given I create an AWSPCAIssuer using a XA CA
+    And I update my certificate spec to issue a CA certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
+    Then the certificate should be issued successfully
+
+    Examples:
+      | certType |
+      | RSA      |
+      | ECDSA    |
+
+  @AWSPCAIssuer
+  Scenario Outline: Issue a short lived certificate with a namespace issuer 
+    Given I create an AWSPCAIssuer using a XA CA
+    And I update my certificate spec to issue a <certType> certificate
+    And I update my certificate spec to issue a certificate with duration of 20 hours
+    And I update my certificate spec to issue a certificate with renew before of 5 hours
+    When I issue the certificate
+    Then the certificate should be issued successfully
+
+    Examples:
+      | certType |
+      | RSA      |
+      | ECDSA    |
 
   @AWSPCAIssuer @KubernetesSecrets
   Scenario Outline: Issue a certificate with a namespace issuer using a secret for AWS credentials
     Given I create a Secret with keys <accessKeyId> and <secretKeyId> for my AWS credentials
     And I create an AWSPCAIssuer using a XA CA
-    When I issue a <certType> certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
     Then the certificate should be issued successfully
 
     Examples:
-      | accessKeyId       | secretKeyId           | certType       |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | SHORT_VALIDITY |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA            |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA          |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | CA             |
+      | accessKeyId       | secretKeyId           | certType |
+      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA      |
+      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA    |
 
     @KeySelectors
     Examples:
-      | accessKeyId       | secretKeyId           | certType       |
-      | myKeyId           | mySecret              | SHORT_VALIDITY |
-      | myKeyId           | mySecret              | RSA            |
-      | myKeyId           | mySecret              | ECDSA          |
-      | myKeyId           | mySecret              | CA             |
+      | accessKeyId       | secretKeyId           | certType |
+      | myKeyId           | mySecret              | RSA      |
+      | myKeyId           | mySecret              | ECDSA    |
 
+  @AWSPCAIssuer @KubernetesSecrets
+  Scenario Outline: Issue a CA certificate with a namespace issuer using a secret for AWS credentials
+    Given I create a Secret with keys <accessKeyId> and <secretKeyId> for my AWS credentials
+    And I create an AWSPCAIssuer using a XA CA
+    And I update my certificate spec to issue a CA certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
+    Then the certificate should be issued successfully
+
+    Examples:
+      | accessKeyId       | secretKeyId           | certType |
+      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA      |
+      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA    |
+
+    @KeySelectors
+    Examples:
+      | accessKeyId       | secretKeyId           | certType |
+      | myKeyId           | mySecret              | RSA      |
+      | myKeyId           | mySecret              | ECDSA    |
+
+  @AWSPCAIssuer @KubernetesSecrets
+  Scenario Outline: Issue a short lived certificate with a namespace issuer using a secret for AWS credentials
+    Given I create a Secret with keys <accessKeyId> and <secretKeyId> for my AWS credentials
+    And I create an AWSPCAIssuer using a XA CA
+    And I update my certificate spec to issue a <certType> certificate
+    And I update my certificate spec to issue a certificate with duration of 20 hours
+    And I update my certificate spec to issue a certificate with renew before of 5 hours
+    When I issue the certificate
+    Then the certificate should be issued successfully
+
+    Examples:
+      | accessKeyId       | secretKeyId           | certType |
+      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA      |
+      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA    |
+
+    @KeySelectors
+    Examples:
+      | accessKeyId       | secretKeyId           | certType |
+      | myKeyId           | mySecret              | RSA      |
+      | myKeyId           | mySecret              | ECDSA    |

--- a/e2e/features/namespace_issuer.feature
+++ b/e2e/features/namespace_issuer.feature
@@ -6,49 +6,68 @@ Feature: Issue certificates using an AWSPCAIssuer
   Background: Create unique namespace
     Given I create a namespace	
 
-  Scenario Outline: Issue a certificate
+  Scenario Outline: Issue a certificate with a ClusterIssuer
     Given I create an AWSPCAIssuer using a <caType> CA
-    When I issue a <certType> certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
     Then the certificate should be issued successfully
 
     Examples:
       | caType | certType       |
-      | RSA    | SHORT_VALIDITY |
       | RSA    | RSA            |
       | RSA    | ECDSA          |
-      | RSA    | CA             |
-      | ECDSA  | SHORT_VALIDITY |
       | ECDSA  | RSA            |
       | ECDSA  | ECDSA          |
-      | ECDSA  | CA             |
+
+  Scenario Outline: Issue a CA certificate with a ClusterIssuer
+    Given I create an AWSPCAIssuer using a <caType> CA
+    And I update my certificate spec to issue a CA certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
+    Then the certificate should be issued successfully
+
+    Examples:
+      | caType | certType       |
+      | RSA    | RSA            |
+      | RSA    | ECDSA          |
+      | ECDSA  | RSA            |
+      | ECDSA  | ECDSA          |
+
+  Scenario Outline: Issue a short lived certificate with a ClusterIssuer
+    Given I create an AWSPCAIssuer using a <caType> CA
+    And I update my certificate spec to issue a <certType> certificate
+    And I update my certificate spec to issue a certificate with duration of 20 hours
+    And I update my certificate spec to issue a certificate with renew before of 5 hours
+    When I issue the certificate
+    Then the certificate should be issued successfully
+
+    Examples:
+      | caType | certType       |
+      | RSA    | RSA            |
+      | RSA    | ECDSA          |
+      | ECDSA  | RSA            |
+      | ECDSA  | ECDSA          |
 
   @KubernetesSecrets
   Scenario Outline: Issue a certificate using a secret for AWS credentials
     Given I create a Secret with keys <accessKeyId> and <secretKeyId> for my AWS credentials
     And I create an AWSPCAIssuer using a <caType> CA
-    When I issue a <certType> certificate
+    And I update my certificate spec to issue a <certType> certificate
+    When I issue the certificate
     Then the certificate should be issued successfully
 
     Examples:
       | accessKeyId       | secretKeyId           | caType | certType       |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA    | SHORT_VALIDITY |
       | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA    | RSA            |
       | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA    | ECDSA          |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | RSA    | CA             |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA  | SHORT_VALIDITY |
       | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA  | RSA            |
       | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA  | ECDSA          |
-      | AWS_ACCESS_KEY_ID | AWS_SECRET_ACCESS_KEY | ECDSA  | CA             |
 
     @KeySelectors
     Examples:
       | accessKeyId       | secretKeyId           | caType | certType       |
-      | myKeyId           | mySecret              | RSA    | SHORT_VALIDITY |
       | myKeyId           | mySecret              | RSA    | RSA            |
       | myKeyId           | mySecret              | RSA    | ECDSA          |
-      | myKeyId           | mySecret              | RSA    | CA             |
-      | myKeyId           | mySecret              | ECDSA  | SHORT_VALIDITY |
       | myKeyId           | mySecret              | ECDSA  | RSA            |
       | myKeyId           | mySecret              | ECDSA  | ECDSA          |
-      | myKeyId           | mySecret              | ECDSA  | CA             |
 

--- a/e2e/features/role_assumption.feature
+++ b/e2e/features/role_assumption.feature
@@ -5,11 +5,13 @@ Feature: Issue certificates using role assumption
 
   Scenario: Issue a certificate with a ClusterIssuer using role assumption
     Given I create an AWSPCAClusterIssuer with role assumption
-    When I issue a RSA certificate
+    And I update my certificate spec to issue a RSA certificate
+    When I issue the certificate
     Then the certificate should be issued successfully
 
   Scenario: Issue a certificate with a namespaced Issuer using role assumption
     Given I create a namespace
     And I create an AWSPCAIssuer with role assumption
-    When I issue a RSA certificate
+    And I update my certificate spec to issue a RSA certificate
+    When I issue the certificate
     Then the certificate should be issued successfully

--- a/e2e/k8_helpers.go
+++ b/e2e/k8_helpers.go
@@ -12,6 +12,7 @@ import (
 	cmclientv1 "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1"
 
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 )
 
 func waitForIssuerReady(ctx context.Context, client *clientV1beta1.Client, name string, namespace string) error {
@@ -97,4 +98,19 @@ func waitForCertificateState(ctx context.Context, client *cmclientv1.Certmanager
 			}
 			return false, nil
 		})
+}
+
+func getCertificateData(ctx context.Context, clientset *kubernetes.Clientset, namespace string, secretName string) ([]byte, error) {
+	secret, err := clientset.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error getting certificate secret %q: %v", secretName, err)
+	}
+
+	// The certificate is stored in the 'tls.crt' key of the secret data
+	certBytes, exists := secret.Data["tls.crt"]
+	if !exists {
+		return nil, fmt.Errorf("certificate data not found in secret %q", secretName)
+	}
+
+	return certBytes, nil
 }


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

Currently, the e2e tests do not verify the content of the certificates. Adding these tests ensure the certificate itself is correctly issued and placed in the correct spot. Grouped with these changes are general testing overhauls of how the certificate spec is constructed by the tests. This should make the tests clearer and more flexible for future use cases

### Description of changes

* Added new CertificateConfig struct that will store all configurations for the certificate spec
* Updated steps to construct the certificate incrementally instead of having hidden configurations based on a type
* Added EKU tests that verify the certificate is issued and the actual certificate includes the EKU
* Added helper functions for extracting the EKU out of the certificate data

### Describe any new or updated permissions being added

None

### Description of how you validated changes

I have run these tests locally

