### PR TITLE
Prevent invalid PodDisruptionBudget configurations

### DIFF
--- a/charts/aws-pca-issuer/templates/pdb.yaml
+++ b/charts/aws-pca-issuer/templates/pdb.yaml
@@ -10,5 +10,17 @@ spec:
   selector:
     matchLabels:
       {{- include "aws-privateca-issuer.selectorLabels" . | nindent 6 }}
-  {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
+
+  {{- /* Ensure at most one of minAvailable or maxUnavailable is set */}}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+
+  {{- /* Set the remaining PDB values */}}
+  {{- $rest := omit .Values.podDisruptionBudget "minAvailable" "maxUnavailable" }}
+  {{- if $rest }}
+    {{-  toYaml $rest | nindent 2 }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

When `minAvailable` is set, `maxUnavailable` is still set by default via `values.yaml`. This results in an invalid `PodDisruptionBudget` that will be rejected by the Kubernetes API, since those two attributes cannot be set simultaneously. `maxUnavailable` must be explicitly set to `null` in order to generate a valid `PodDisruptionBudget`.

#### Before Fix

The following command shows how the [suggested example in values.yaml](https://github.com/cert-manager/aws-privateca-issuer/blob/0ce98d6fbf29cb577593cbb75482dbd0ff5c6e61/charts/aws-pca-issuer/values.yaml#L172) renders an invalid `PodDisruptionBudget`.

**Command**:
```
helm template test-release ./charts/aws-pca-issuer --set 'podDisruptionBudget.minAvailable=1' | yq -y 'select(.kind == "PodDisruptionBudget")'
```

**Output**:
``` yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: test-release-aws-privateca-issuer
  # ...
spec:
  # ...
  maxUnavailable: 1
  minAvailable: 1
```

### Description of changes

A conditional statement is added in `pdb.yaml` that sets only one of `podDisruptionBudget.minAvailable` or `podDisruptionBudget.maxUnavailable`.

#### After Fix

The following command shows that when `podDisruptionBudget.minAvailable` is set, `spec.maxUnavailable` will not be set:

**Command**:
```
helm template test-release ./charts/aws-pca-issuer --set 'podDisruptionBudget.minAvailable=1' | yq -y 'select(.kind == "PodDisruptionBudget")'
```

**Output**:
``` yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: test-release-aws-privateca-issuer
  # ...
spec:
  # ...
  minAvailable: 1
```

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

Tested locally using Helm v3.18.6 by running the `helm template` commands shown above.
