### PR TITLE
Handle conflict errors on CertificateRequest updates

### DIFF
--- a/pkg/controllers/certificaterequest_controller.go
+++ b/pkg/controllers/certificaterequest_controller.go
@@ -179,7 +179,15 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, r.setStatus(ctx, cr, cmmeta.ConditionFalse, cmapi.CertificateRequestReasonFailed, "failed to request certificate from PCA: "+err.Error())
 		}
 
-		return ctrl.Result{Requeue: true}, r.Client.Update(ctx, cr)
+		err = r.Client.Update(ctx, cr)
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				log.Info("conflict updating CertificateRequest, will requeue")
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	pem, ca, err := provisioner.Get(ctx, cr, certArn, log)
@@ -223,5 +231,11 @@ func (r *CertificateRequestReconciler) setStatus(ctx context.Context, cr *cmapi.
 		eventType = core.EventTypeWarning
 	}
 	r.Recorder.Event(cr, eventType, reason, message)
-	return r.Client.Status().Update(ctx, cr)
+	err := r.Client.Status().Update(ctx, cr)
+	if apierrors.IsConflict(err) {
+		r.Log.WithValues("certificaterequest", types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}).
+			Info("conflict updating CertificateRequest status, will requeue")
+		return nil
+	}
+	return err
 }

--- a/pkg/controllers/certificaterequest_controller_test.go
+++ b/pkg/controllers/certificaterequest_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -38,6 +39,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	issuerapi "github.com/cert-manager/aws-privateca-issuer/pkg/api/v1beta1"
@@ -648,6 +650,7 @@ func TestCertificateRequestReconcile(t *testing.T) {
 
 			if tc.mockProvisioner != nil {
 				GetProvisioner = tc.mockProvisioner
+				t.Cleanup(awspca.ClearProvisioners)
 			}
 
 			result, signErr := controller.Reconcile(ctx, reconcile.Request{NamespacedName: tc.name})
@@ -679,7 +682,6 @@ func TestCertificateRequestReconcile(t *testing.T) {
 					assert.Equal(t, tc.expectedCACertificate, cr.Status.CA)
 				}
 			}
-			awspca.ClearProvisioners()
 		})
 	}
 }
@@ -697,4 +699,70 @@ func assertCertificateRequestHasReadyCondition(t *testing.T, status cmmeta.Condi
 	)
 	assert.Contains(t, validReasons, reason, "unexpected condition reason")
 	assert.Equal(t, reason, condition.Reason, "unexpected condition reason")
+}
+
+func TestCertificateRequestReconcile_UpdateConflict(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, issuerapi.AddToScheme(scheme))
+	require.NoError(t, cmapi.AddToScheme(scheme))
+	require.NoError(t, v1.AddToScheme(scheme))
+
+	objects := []client.Object{
+		cmgen.CertificateRequest(
+			"cr1",
+			cmgen.SetCertificateRequestNamespace("ns1"),
+			cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
+				Name:  "issuer1",
+				Group: issuerapi.GroupVersion.Group,
+				Kind:  "Issuer",
+			}),
+			cmgen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+				Type:   cmapi.CertificateRequestConditionReady,
+				Status: cmmeta.ConditionUnknown,
+			}),
+		),
+		&issuerapi.AWSPCAIssuer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "issuer1",
+				Namespace: "ns1",
+			},
+			Spec: issuerapi.AWSPCAIssuerSpec{
+				Region: "us-east-1",
+				Arn:    "arn:aws:acm-pca:us-east-1:account:certificate-authority/12345678-1234-1234-1234-123456789012",
+			},
+			Status: issuerapi.AWSPCAIssuerStatus{
+				Conditions: []metav1.Condition{
+					{Type: issuerapi.ConditionTypeReady, Status: metav1.ConditionTrue},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(objects...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				return apierrors.NewConflict(cmapi.Resource("certificaterequests"), "cr1", errors.New("conflict"))
+			},
+		}).
+		Build()
+
+	controller := CertificateRequestReconciler{
+		Client:   fakeClient,
+		Log:      logrtesting.NewTestLogger(t),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	GetProvisioner = generateMockGetProvisioner(&fakeProvisioner{cert: []byte("cert"), caCert: []byte("cacert")}, nil)
+	t.Cleanup(awspca.ClearProvisioners)
+
+	result, err := controller.Reconcile(context.TODO(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "cr1"},
+	})
+
+	assert.NoError(t, err, "conflict should not return an error")
+	assert.True(t, result.Requeue, "conflict should trigger requeue")
 }


### PR DESCRIPTION
### Issue #446

Closes #446.

### Reason for this change

When cert-manager updates a CertificateRequest (e.g., setting lastTransitionTime) concurrently with the aws-privateca-issuer updating the same resource, an optimistic locking conflict occurs. Previously this error bubbled up to controller-runtime, incrementing controller_runtime_reconcile_errors_total and causing false positive alerts.

Now conflict errors on Update trigger a requeue without returning an error, which is the standard Kubernetes pattern for handling optimistic locking conflicts.

### Description of changes

- Checks if the error received was a conflict error. If so, this has updated the logic to just re-queue the request and not surface the error to the controller.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

Re-produced using customer provided steps. I was able to confirm seeing the conflict errors in the logs were not present after making this change

