### PR TITLE
Update kube-rbac-proxy image to registry.k8s.io

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
`gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0` returns 404. Update `config/default/manager_auth_proxy_patch.yaml` to `registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.5.0` (same version, new registry host).

Fixes #353