### PR TITLE
Use UUIDs instead of timestamps for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # The version which will be reported by the --version argument of each binary
 # and which will be used as the Docker image tag
-VERSION := $(shell git remote add mainRepo https://github.com/cert-manager/aws-privateca-issuer.git && git fetch mainRepo --tags && git describe --tags | awk -F"-" '{print $$1}' && git remote remove mainRepo)
+VERSION := $(shell git fetch --tags --force https://github.com/cert-manager/aws-privateca-issuer.git 2>/dev/null; git describe --tags 2>/dev/null | awk -F"-" '{print $$1}')
 
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
@@ -227,9 +227,10 @@ SERVICE_ACCOUNT := ${NAMESPACE}-${ARCH}-sa
 TEST_KUBECONFIG_LOCATION := /tmp/pca_kubeconfig
 
 create-local-registry:
+	docker network create kind 2>/dev/null || true
 	RUNNING=$$(docker inspect -f '{{.State.Running}}' ${REGISTRY_NAME} 2>/dev/null || true)
 	if [ "$$RUNNING" != 'true' ]; then
-		docker run -d --restart=always -p "127.0.0.1:${REGISTRY_PORT}:5000" --name ${REGISTRY_NAME} registry:2
+		docker run -d --restart=always -p "127.0.0.1:${REGISTRY_PORT}:5000" --network kind --name ${REGISTRY_NAME} registry:2
 	fi
 	sleep 15
 
@@ -252,7 +253,6 @@ kind-cluster: ${KIND}
 	${KIND} get clusters | grep ${K8S_CLUSTER_NAME} || \
 	${KIND} create cluster --name ${K8S_CLUSTER_NAME} --config=/tmp/config.yaml
 	${KIND} get kubeconfig --name ${K8S_CLUSTER_NAME} > ${TEST_KUBECONFIG_LOCATION}
-	docker network connect "kind" ${REGISTRY_NAME} || true
 	kubectl apply -f e2e/kind_config/registry_configmap.yaml --kubeconfig=${TEST_KUBECONFIG_LOCATION}
 	#Create namespace and service account
 	kubectl get namespace ${NAMESPACE} --kubeconfig=${TEST_KUBECONFIG_LOCATION} || \

--- a/e2e/aws_helpers.go
+++ b/e2e/aws_helpers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"log"
-	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -16,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ram"
 	ramtypes "github.com/aws/aws-sdk-go-v2/service/ram/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/google/uuid"
 )
 
 type statementEntry struct {
@@ -62,7 +62,7 @@ func createUser(ctx context.Context, cfg aws.Config) (string, string) {
 		panic(err.Error())
 	}
 
-	policyName := "CMPolicy" + strconv.FormatInt(time.Now().Unix(), 10)
+	policyName := "CMPolicy-" + uuid.NewString()
 
 	policyParams := iam.CreatePolicyInput{
 		PolicyName:     aws.String(policyName),
@@ -77,7 +77,7 @@ func createUser(ctx context.Context, cfg aws.Config) (string, string) {
 
 	policyArn := policyOutput.Policy.Arn
 
-	userName := "CMUser" + strconv.FormatInt(time.Now().Unix(), 10)
+	userName := "CMUser-" + uuid.NewString()
 
 	userParams := iam.CreateUserInput{
 		UserName:            aws.String(userName),
@@ -190,7 +190,7 @@ func deleteCertificateAuthority(ctx context.Context, cfg aws.Config, caArn strin
 func (testCtx *TestContext) createCertificateAuthority(ctx context.Context, cfg aws.Config, isRSA bool) string {
 	var caParams caParams
 	caParams.caType = types.CertificateAuthorityTypeRoot
-	caParams.commonName = "CMTest-" + strconv.FormatInt(time.Now().Unix(), 10)
+	caParams.commonName = "CMTest-" + uuid.NewString()
 	caParams.issuerCAArn = nil // will be self-signed later
 	caParams.templateArn = "arn:aws:acm-pca:::template/RootCACertificate/V1"
 	caParams.validity = types.Validity{
@@ -205,7 +205,7 @@ func createSubCertificateAuthority(ctx context.Context, cfg aws.Config, isRSA bo
 	var caParams caParams
 
 	caParams.caType = types.CertificateAuthorityTypeSubordinate
-	caParams.commonName = "CMSubordinate-" + strconv.FormatInt(time.Now().Unix(), 10)
+	caParams.commonName = "CMSubordinate-" + uuid.NewString()
 	caParams.issuerCAArn = &parentCAArn
 	caParams.templateArn = "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen1/V1"
 	caParams.validity = types.Validity{

--- a/e2e/awspcaissuer_test.go
+++ b/e2e/awspcaissuer_test.go
@@ -95,6 +95,9 @@ func InitializeTestSuite(suiteCtx *godog.TestSuiteContext) {
 			panic(fmt.Sprintf("Ensure that that the kubeconfig for the cluster that is being tested is placed in %s", KubeConfigPath))
 		}
 
+		clientConfig.QPS = -1
+		clientConfig.Burst = -1
+
 		testContext.clientset, err = kubernetes.NewForConfig(clientConfig)
 		if err != nil {
 			panic(err.Error())

--- a/e2e/k8_helpers.go
+++ b/e2e/k8_helpers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +57,8 @@ func waitForCertificateRequestState(ctx context.Context, client *cmclientv1.Cert
 		func(ctx context.Context) (bool, error) {
 			cr, err := client.CertificateRequests(namespace).Get(ctx, name, metav1.GetOptions{})
 			if err != nil {
-				return false, fmt.Errorf("error getting CertificateRequest %q: %v", name, err)
+				log.Printf("Waiting for CertificateRequest %q: %v", name, err)
+				return false, nil
 			}
 
 			for _, condition := range cr.Status.Conditions {

--- a/pkg/controllers/genericissuer_controller_test.go
+++ b/pkg/controllers/genericissuer_controller_test.go
@@ -41,6 +41,10 @@ const (
 )
 
 func TestIssuerReconcile(t *testing.T) {
+	origAWSDefaultRegion := awsDefaultRegion
+	awsDefaultRegion = ""
+	t.Cleanup(func() { awsDefaultRegion = origAWSDefaultRegion })
+
 	type testCase struct {
 		kind                         string
 		name                         types.NamespacedName


### PR DESCRIPTION
### Issue # N/A

### Reason for this change

This ensures resources are unique across test runs. Specifically, in instances where you are running a lot of tests in parallel.

### Description of changes

e2e test resources now use UUIDs instead of timestamps for uniqueness. Also removed client side rate limiting

### Describe any new or updated permissions being added

None

### Description of how you validated changes

Ran tests locally

