### PR TITLE
Use dynamic partition in e2e template ARNs

### DIFF
--- a/e2e/aws_helpers.go
+++ b/e2e/aws_helpers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"time"
 
@@ -192,7 +193,7 @@ func (testCtx *TestContext) createCertificateAuthority(ctx context.Context, cfg 
 	caParams.caType = types.CertificateAuthorityTypeRoot
 	caParams.commonName = "CMTest-" + uuid.NewString()
 	caParams.issuerCAArn = nil // will be self-signed later
-	caParams.templateArn = "arn:aws:acm-pca:::template/RootCACertificate/V1"
+	caParams.templateArn = fmt.Sprintf("arn:%s:acm-pca:::template/RootCACertificate/V1", testCtx.partition)
 	caParams.validity = types.Validity{
 		Type:  types.ValidityPeriodTypeYears,
 		Value: aws.Int64(365),
@@ -201,13 +202,13 @@ func (testCtx *TestContext) createCertificateAuthority(ctx context.Context, cfg 
 	return createCertificateAuthority(ctx, cfg, caParams, isRSA)
 }
 
-func createSubCertificateAuthority(ctx context.Context, cfg aws.Config, isRSA bool, parentCAArn string) string {
+func (testCtx *TestContext) createSubCertificateAuthority(ctx context.Context, cfg aws.Config, isRSA bool, parentCAArn string) string {
 	var caParams caParams
 
 	caParams.caType = types.CertificateAuthorityTypeSubordinate
 	caParams.commonName = "CMSubordinate-" + uuid.NewString()
 	caParams.issuerCAArn = &parentCAArn
-	caParams.templateArn = "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen1/V1"
+	caParams.templateArn = fmt.Sprintf("arn:%s:acm-pca:::template/SubordinateCACertificate_PathLen1/V1", testCtx.partition)
 	caParams.validity = types.Validity{
 		Type:  types.ValidityPeriodTypeYears,
 		Value: aws.Int64(30),

--- a/e2e/awspcaissuer_test.go
+++ b/e2e/awspcaissuer_test.go
@@ -149,10 +149,10 @@ func InitializeTestSuite(suiteCtx *godog.TestSuiteContext) {
 		log.Printf("Created EC CA with arn %s", testContext.caArns["ECDSA"])
 
 		// Create subordinate CAs for template testing
-		testContext.caArns["RSA-SUB"] = createSubCertificateAuthority(ctx, cfg, true, testContext.caArns["RSA"])
+		testContext.caArns["RSA-SUB"] = testContext.createSubCertificateAuthority(ctx, cfg, true, testContext.caArns["RSA"])
 		log.Printf("Created RSA-SUB CA with arn %s", testContext.caArns["RSA-SUB"])
 
-		testContext.caArns["ECDSA-SUB"] = createSubCertificateAuthority(ctx, cfg, false, testContext.caArns["ECDSA"])
+		testContext.caArns["ECDSA-SUB"] = testContext.createSubCertificateAuthority(ctx, cfg, false, testContext.caArns["ECDSA"])
 		log.Printf("Created ECDSA-SUB CA with arn %s", testContext.caArns["ECDSA-SUB"])
 
 		xaRole, xaRoleExists := os.LookupEnv(CrossAccountRoleKey)


### PR DESCRIPTION
### Issue # N/A

N/A

### Reason for this change

This will allow tests to successfully run in other AWS partitions.

### Description of changes

Removes hard-coded AWS partition.

### Describe any new or updated permissions being added

None

### Description of how you validated changes

Ran tests

