### PR TITLE
fix(ci): opt in to fork checkout explicitly and scope the token that sees it

### DIFF
--- a/.github/workflows/on-safe-to-test-label.yml
+++ b/.github/workflows/on-safe-to-test-label.yml
@@ -63,15 +63,27 @@ jobs:
     name: Do the job on the runner
     needs: start-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
+    # This job builds and runs the pull request's own code (its Makefile, scripts
+    # and dependencies), so treat it as untrusted: no id-token, and no token left
+    # behind on the runner for that code to find.
+    permissions:
+      contents: read
     steps:
       - name: Install Git
         run: sudo yum install git -y
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
+          # Checking out fork code under pull_request_target is a "pwn request"
+          # risk; https://gh.io/securely-using-pull_request_target. Accepted here
+          # because the run is gated on a maintainer applying the 'safe to test'
+          # label, pinned to the sha that was labelled, and confined to an
+          # ephemeral runner in the test account.
+          allow-unsafe-pr-checkout: true
       - name: Install Development Tools
         run: |
           sudo yum groupinstall "Development Tools" -y

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -7,15 +7,24 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# pull_request_target runs with the base repository's token, so grant it per job
+# rather than relying on the repository default. A called workflow can only ever
+# reduce what is granted here, so these must cover what its jobs request.
 jobs:
   run-for-arm:
     if: ${{ (contains(github.event.pull_request.labels.*.name, 'safe to test') && !contains(github.event.pull_request.labels.*.name, 'lgtm')) || (contains(github.event_name, 'workflow_dispatch')) }}
+    permissions:
+      id-token: write # assume the testing role via OIDC
+      contents: read
     uses: './.github/workflows/on-safe-to-test-label.yml'
     with:
       architecture: 'arm64'
 
   run-for-x86:
     if: ${{ (contains(github.event.pull_request.labels.*.name, 'safe to test') && !contains(github.event.pull_request.labels.*.name, 'lgtm')) || (contains(github.event_name, 'workflow_dispatch')) }}
+    permissions:
+      id-token: write # assume the testing role via OIDC
+      contents: read
     uses: './.github/workflows/on-safe-to-test-label.yml'
     with:
       architecture: 'x86_64'
@@ -24,6 +33,8 @@ jobs:
     name: Remove Safe to Test Label
     needs: run-for-x86
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # the only thing this job does is drop the label
     if: ${{ contains(github.event.pull_request.labels.*.name, 'safe to test') && !contains(github.event.pull_request.labels.*.name, 'lgtm') && always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Remove Label


### PR DESCRIPTION
### Issue # N/A

N/A

### Reason for this change

actions/checkout backported its pull_request_target guard to v4.4.0, so the
floating @v4 tag started refusing the fork checkout in do-the-job and the e2e
run fails before it starts:

### Description of changes

- do-the-job now declares permissions: contents: read, so the job that runs
  fork code no longer inherits the repository default and cannot mint an OIDC
  token. Its checkout sets persist-credentials: false, so no base-repo token is
  left in .git/config for that code to read.
- allow-unsafe-pr-checkout: true on that step, with a comment recording why the
  residual risk is accepted: a maintainer must apply the 'safe to test' label,
  the run is pinned to the sha that was labelled, and it is confined to an
  ephemeral runner in the test account.
- Pin that checkout to the v4.4.0 sha. A floating tag rolling onto new
  behaviour is what broke this in the first place.
- test-plugin.yml grants permissions per job. A called workflow can only reduce
  the caller's grant, so the two run-for-* jobs must keep id-token: write for
  the AWS role; remove-safe-to-test needs only pull-requests: write.

### Describe any new or updated permissions being added

N/A

### Description of how you validated changes

N/A

