### PR TITLE
fix(ci): bump ec2-github-runner to pick up runner registration fix

### DIFF
--- a/.github/workflows/on-safe-to-test-label.yml
+++ b/.github/workflows/on-safe-to-test-label.yml
@@ -40,7 +40,7 @@ jobs:
           echo AMI=$AMI >> $GITHUB_ENV
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: aws-pca-k8s-plugin-ops-admin/ec2-github-runner@001b8975c07ebdbc838650b9ff7635735f915c5f
+        uses: aws-pca-k8s-plugin-ops-admin/ec2-github-runner@46a464e192039be36e1066c49baeabded9065c51
         with:
           mode: start
           github-token: GithubToken-test-us-east-1
@@ -255,7 +255,7 @@ jobs:
           AWS_REGION=us-east-1
           echo AWS_REGION=$AWS_REGION >> $GITHUB_ENV
       - name: Stop EC2 runner
-        uses: aws-pca-k8s-plugin-ops-admin/ec2-github-runner@001b8975c07ebdbc838650b9ff7635735f915c5f
+        uses: aws-pca-k8s-plugin-ops-admin/ec2-github-runner@46a464e192039be36e1066c49baeabded9065c51
         with:
           mode: stop
           github-token: GithubToken-test-us-east-1


### PR DESCRIPTION
GitHub raised the minimum self-hosted runner version to 2.329.0, above the
2.312.0 the pinned ec2-github-runner hardcoded, so both start-runner jobs failed
with "A timeout of 5 minutes is exceeded. Your AWS EC2 instance was not able to
register itself in GitHub as a new self-hosted runner." The instance was healthy;
the console output showed config.sh getting a 404 from
/actions/runner-registration and the runner exiting 25s after boot.

Repoint both start and stop steps at the merged fix, which resolves the runner
version at boot instead of hardcoding it, and moves the action off node12.

Upstream fix: aws-pca-k8s-plugin-ops-admin/ec2-github-runner#3, merged as `46a464e`.

## Diagnosis

Console output from the failed instance (`i-01e59c9c9e32bea35`, run 33412080058):

```
Http response code: NotFound from 'POST https://api.github.com/actions/runner-registration'
ERROR: Your runner version is out of date and can no longer register with GitHub.
│   The minimum runner version required to register with GitHub Actions is now 2.329.0.
An error occurred: Not configured. Run config.(sh/cmd) to configure the runner.
```

libicu installed and the 179.9 MB tarball downloaded at 198 MB/s, so neither egress, the AMI, nor the `GithubToken-test-us-east-1` secret was at fault — auth got far enough to be refused on *version*, not credentials. Both architectures failed identically, consistent with a cause common to both AMIs.

## Why this targets main

`test-plugin.yml` triggers on `pull_request_target`, so GitHub loads it — and the locally-referenced `on-safe-to-test-label.yml` — from the **base** branch. Landing this on a release branch would not affect PRs based on main.

## Testing

- Verified `46a464e` is on the fork's `main`, its `dist/index.js` contains the boot-time resolver, and no `2.312.0` remains in it.
- Not yet exercised end to end: the first real proof is a `safe to test` run after this merges.